### PR TITLE
Relaying image attachments

### DIFF
--- a/rs/offchain/examples/discord/README.md
+++ b/rs/offchain/examples/discord/README.md
@@ -52,7 +52,7 @@ Keep the API key secure, it's a secret!
 
 ## How to run
 
-For the _Discord_ bot to start up properly you will need a `config.toml`. The easies way to set it up is to copy the `exmaples/discord/sample.config.toml` from the repository, and modify it.
+For the _Discord_ bot to start up properly you will need a `config.toml`. The easiest way to set it up is to copy the `exmaples/discord/sample.config.toml` from the repository, and modify it.
 
 Once you have the configuration file all set up, place its path into your `rs/.env` file to tell the bot where to find it:
 ```

--- a/rs/offchain/examples/discord/src/discord.rs
+++ b/rs/offchain/examples/discord/src/discord.rs
@@ -6,15 +6,15 @@ use crate::config::DiscordConfig;
 use crate::discord::commands as discord_commands;
 use crate::discord::events::event_handler;
 use crate::errors::BotError;
-use crate::openchat::RelayMessage;
 use crate::state::BotState;
 use poise::serenity_prelude as serenity;
+use serenity::Message;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tracing::info;
 
 pub struct LocalData {
-    pub tx: Sender<RelayMessage>,
+    pub tx: Sender<Message>,
     pub state: Arc<BotState>,
 }
 
@@ -32,7 +32,7 @@ pub type FrameworkContext<'a> = poise::FrameworkContext<'a, LocalData, Error>;
 pub async fn init_discord_client(
     config: &DiscordConfig,
     state: Arc<BotState>,
-    tx: Sender<RelayMessage>,
+    tx: Sender<Message>,
 ) -> Result<serenity::Client, BotError> {
     let local_data = LocalData { tx, state };
 

--- a/rs/offchain/examples/discord/src/discord/events.rs
+++ b/rs/offchain/examples/discord/src/discord/events.rs
@@ -1,8 +1,6 @@
 use crate::discord::{types::ChannelStatus, Error, FrameworkContext, LocalData};
-use crate::openchat::RelayMessage;
-use poise::serenity_prelude as serenity;
-use serenity::Message;
-use tracing::{debug, error, info, warn};
+use poise::serenity_prelude::{self as serenity, Message};
+use tracing::{debug, error, info};
 
 pub async fn event_handler(
     ctx: &serenity::Context,
@@ -37,53 +35,22 @@ async fn proxy_message(
     let not_bot_itself = new_message.author.id != ctx.cache.current_user().id;
 
     if not_bot_itself {
-        // Attachments will hold any image/video/other that is sent with a message.
-        // We are filtering out messages with no content and attachments.
-        // TODO allow attachments to be sent to OpenChat
-        if new_message.content.is_empty() && !new_message.attachments.is_empty() {
-            warn!(
-                new_message.author.name,
-                "Unsupported messsage type - attachments are not yet handled!"
-            );
-            return Ok(());
-        }
+        debug!("Relaying message :: {:#?}", new_message);
 
-        // Get OC destination channel token!
-        let channel_id = new_message.channel_id;
-        // State is shared, so tokens can also be accessed on the other side
-        // of the tx/rx channel.
-        let oc_token = data.state.get_token_for_oc_channel(channel_id).await;
+        // Broadcast message, to be picked up by the OC agent!
+        let res = data.tx.send(new_message.clone()).await;
 
-        debug!("Relaying message :: {:?}", new_message);
-
-        if let Some(token) = oc_token {
-            // Broadcast message, to be picked up by the OC agent!
-            let res = data
-                .tx
-                .send(RelayMessage::from_message(new_message.clone(), token))
-                .await;
-
-            let channel_status = if let Err(e) = res {
-                // TODO: a recovery mechanism?
-                error!("Failed to send message to OC :: {}", e);
-                ChannelStatus::ProxyFailed("Failed to send message to OC".to_string())
-            } else {
-                ChannelStatus::Operational
-            };
-
-            data.state
-                .set_status_for_ds_channel(channel_id, channel_status)
-                .await?;
+        let channel_status = if let Err(e) = res {
+            // TODO a recovery mechanism
+            error!("Failed to push message to OC bot :: {}", e);
+            ChannelStatus::ProxyFailed("Message did not reach OpenChat handler bot!".to_string())
         } else {
-            // TODO figure out how to get channel name
-            info!(
-                "Cannot proxy message, OpenChat token is not set for Discord channel with id :: {}",
-                new_message.channel_id
-            );
-            data.state
-                .set_status_for_ds_channel(channel_id, ChannelStatus::TokenNotSet)
-                .await?;
-        }
+            ChannelStatus::Operational
+        };
+
+        data.state
+            .set_status_for_ds_channel(new_message.channel_id, channel_status)
+            .await?;
 
         // This is just for fun!
         let msg = new_message.content.clone().to_lowercase();

--- a/rs/offchain/examples/discord/src/openchat.rs
+++ b/rs/offchain/examples/discord/src/openchat.rs
@@ -14,6 +14,7 @@ use oc_bots_sdk::api::command_handler::CommandHandler;
 use oc_bots_sdk::api::{BotDefinition, CommandResponse, MessagePermission};
 use oc_bots_sdk::oc_api::client_factory::ClientFactory;
 use oc_bots_sdk_offchain::{env, AgentRuntime};
+use poise::serenity_prelude::Message;
 use std::collections::HashSet;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
@@ -61,14 +62,12 @@ pub async fn init_openchat_client(
 pub async fn start_openchat_bot(
     data: Arc<OcData>,
     port: u16,
-    rx: Receiver<RelayMessage>,
+    rx: Receiver<Message>,
 ) -> Result<(), BotError> {
     // Start listening for messages comming from the Discord bot
-    let thread_client = data.oc_client.clone();
-    let thread_config = data.oc_config.clone();
-    let oc_events = tokio::spawn(async move {
-        events::handle_openchat_events(thread_client, thread_config, rx).await
-    });
+    let thread_data = data.clone();
+    let oc_events =
+        tokio::spawn(async move { events::handle_openchat_events(thread_data, rx).await });
 
     // OC bot setup!
     let routes = Router::new()

--- a/rs/offchain/examples/discord/src/openchat/events.rs
+++ b/rs/offchain/examples/discord/src/openchat/events.rs
@@ -1,48 +1,96 @@
-use crate::config::OpenChatConfig;
+use crate::discord::types::ChannelStatus;
 use crate::errors::BotError;
-use crate::openchat::types::RelayMessage;
+use crate::openchat::OcData;
 use oc_bots_sdk::oc_api::actions::ActionArgsBuilder;
-use oc_bots_sdk::oc_api::client_factory::ClientFactory;
 use oc_bots_sdk::types::{AuthToken, BotApiKeyContext, MessageContent, TextContent};
 use oc_bots_sdk_offchain::env;
-use oc_bots_sdk_offchain::AgentRuntime;
+use poise::serenity_prelude::Message;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
 use tracing::{error, info};
 
 pub async fn handle_openchat_events(
-    oc_client: Arc<ClientFactory<AgentRuntime>>,
-    oc_config: OpenChatConfig,
-    mut rx: Receiver<RelayMessage>,
+    data: Arc<OcData>,
+    mut rx: Receiver<Message>,
 ) -> Result<(), BotError> {
     info!("Awaiting for Discord messages");
 
     while let Some(message) = rx.recv().await {
-        let auth_token = AuthToken::ApiKey(message.oc_api_token.0);
-        let context = BotApiKeyContext::parse(auth_token, &oc_config.public_key, env::now());
+        // Get token for the channel in which the message was sent!
+        let oc_api_token = data
+            .state
+            .get_token_for_oc_channel(message.channel_id)
+            .await;
 
-        match context {
-            Ok(ctx) => {
-                info!(
-                    "Relay Discord message :: [{}] > {}",
-                    message.oc_message.ds_user_name, message.oc_message.content
-                );
+        // If the token is available!
+        if let Some(api_token) = oc_api_token {
+            let auth_token = AuthToken::ApiKey(api_token.0);
 
-                let msg = message.oc_message;
-                let res = oc_client
-                    .build_api_key_client(ctx)
-                    .send_message(MessageContent::Text(TextContent {
-                        text: format!("**[ {} ]** {}", msg.ds_user_name, msg.content),
-                    }))
-                    .execute_async()
-                    .await;
+            info!(
+                "Relay Discord message :: [{}] > {}",
+                message.author.name, message.content
+            );
 
-                if let Err(err) = res {
-                    error!("Could not relay message :: {:?}", err);
+            let author = format!("**[{}]** {}", message.author.name, message.content);
+            let images: Vec<String> = message
+                .attachments
+                .into_iter()
+                .filter_map(|attach| {
+                    let content_type = attach.content_type.unwrap_or(String::new());
+                    if content_type.starts_with("image/") {
+                        Some(format!(
+                            "🔗 [{}: {}]({})",
+                            content_type, attach.filename, attach.url
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            // TODO Can we recover if this fails? Could the context be clone-able?
+            match BotApiKeyContext::parse(
+                auth_token.clone(),
+                &data.oc_config.public_key,
+                env::now(),
+            ) {
+                Ok(ctx) => {
+                    let text = [author, images.join("\n")].join("\n\n");
+
+                    // TODO add recovery mechanism with backpressure for the request.
+                    let res = data
+                        .oc_client
+                        .build_api_key_client(ctx)
+                        .send_message(MessageContent::Text(TextContent { text }))
+                        .execute_async()
+                        .await;
+
+                    let channel_status = if let Err(err) = res {
+                        error!("Failed to send message to OC :: {:?}", err);
+                        ChannelStatus::ProxyFailed(
+                            "OpenChat bot could not push message to an OC channel.".to_string(),
+                        )
+                    } else {
+                        ChannelStatus::Operational
+                    };
+
+                    data.state
+                        .set_status_for_ds_channel(message.channel_id, channel_status)
+                        .await?;
                 }
+                Err(err) => error!("Failed to obtain OC bot context :: {:?}", err),
             }
-            Err(err) => error!("Relay message error :: {:?}", err),
-        };
+        } else {
+            // TODO figure out how to get channel name
+            info!(
+                "Cannot proxy message, OpenChat token is not set for Discord channel with id :: {}",
+                message.channel_id
+            );
+            data.state
+                // TODO maybe the channel status is a common type
+                .set_status_for_ds_channel(message.channel_id, ChannelStatus::TokenNotSet)
+                .await?;
+        }
     }
 
     Ok(())

--- a/rs/offchain/examples/discord/src/openchat/types.rs
+++ b/rs/offchain/examples/discord/src/openchat/types.rs
@@ -2,9 +2,7 @@ use crate::{config::OpenChatConfig, state::BotState};
 use oc_bots_sdk::api::command_handler::CommandHandler;
 use oc_bots_sdk::oc_api::client_factory::ClientFactory;
 use oc_bots_sdk_offchain::AgentRuntime;
-use poise::serenity_prelude as serenity;
 use serde::{Deserialize, Serialize};
-use serenity::{ChannelId, Message, Timestamp, UserId};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -31,43 +29,6 @@ impl OcData {
             oc_config,
             commands: Arc::new(commands),
             state,
-        }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct RelayMessage {
-    pub oc_message: OcMessage,
-    pub oc_api_token: OcToken,
-}
-
-impl RelayMessage {
-    pub fn from_message(message: Message, oc_api_token: OcToken) -> Self {
-        Self {
-            oc_message: message.into(),
-            oc_api_token,
-        }
-    }
-}
-
-// Message to be relayed to the OpenChat API
-#[derive(Clone, Debug)]
-pub struct OcMessage {
-    pub ds_channel_id: ChannelId,
-    pub ds_user_id: UserId,
-    pub ds_user_name: String,
-    pub content: String,
-    pub timestamp: Timestamp,
-}
-
-impl From<Message> for OcMessage {
-    fn from(message: Message) -> Self {
-        Self {
-            ds_channel_id: message.channel_id,
-            ds_user_id: message.author.id,
-            ds_user_name: message.author.name,
-            content: message.content,
-            timestamp: message.timestamp,
         }
     }
 }


### PR DESCRIPTION
Relay images attached to Discord messages. This solution is a bit clunky, but should allow more data to be passed between the apps. Youtube links for example are passed really nicely, and even render an embedded player.

Also, got rid of the RelayMessage, which revealed it was indeed not necessary.

![image](https://github.com/user-attachments/assets/9684e9af-53b2-4113-a438-58155d80d058)
