### PR TITLE
Allow attachments to be sent to OC

### DIFF
--- a/rs/offchain/examples/discord/src/discord/events.rs
+++ b/rs/offchain/examples/discord/src/discord/events.rs
@@ -51,15 +51,6 @@ async fn proxy_message(
         data.state
             .set_status_for_ds_channel(new_message.channel_id, channel_status)
             .await?;
-
-        // This is just for fun!
-        let msg = new_message.content.clone().to_lowercase();
-        let words: Vec<&str> = msg.split_whitespace().collect();
-        if words.contains(&"ping") {
-            new_message
-                .reply(ctx, "You've mentioned a ping! Here's a pong!")
-                .await?;
-        }
     }
 
     Ok(())

--- a/rs/offchain/examples/discord/src/openchat/events.rs
+++ b/rs/offchain/examples/discord/src/openchat/events.rs
@@ -7,7 +7,7 @@ use oc_bots_sdk_offchain::env;
 use poise::serenity_prelude::Message;
 use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 pub async fn handle_openchat_events(
     data: Arc<OcData>,
@@ -32,12 +32,11 @@ pub async fn handle_openchat_events(
             );
 
             let author = format!("**[{}]** {}", message.author.name, message.content);
-            let images: Vec<String> = message
+            let attachments: Vec<String> = message
                 .attachments
                 .into_iter()
                 .filter_map(|attach| {
-                    let content_type = attach.content_type.unwrap_or_default();
-                    if content_type.starts_with("image/") {
+                    if let Some(content_type) = attach.content_type {
                         Some(format!(
                             "🔗 [{}: {}]({})",
                             content_type, attach.filename, attach.url
@@ -48,42 +47,63 @@ pub async fn handle_openchat_events(
                 })
                 .collect();
 
-            // TODO Can we recover if this fails? Could the context be clone-able?
-            match BotApiKeyContext::parse(
-                auth_token.clone(),
-                &data.oc_config.public_key,
-                env::now(),
-            ) {
-                Ok(ctx) => {
-                    let text = [author, images.join("\n")].join("\n\n");
+            let stickers: Vec<String> = message
+                .sticker_items
+                .into_iter()
+                .map(|sticker| format!("📌 Sticker shared: {}", sticker.name))
+                .collect();
 
-                    // TODO add recovery mechanism with backpressure for the request.
-                    let res = data
-                        .oc_client
-                        .build_api_key_client(ctx)
-                        .send_message(MessageContent::Text(TextContent { text }))
-                        .execute_async()
-                        .await;
+            if !(message.content.is_empty() && attachments.is_empty() && stickers.is_empty()) {
+                // TODO Can we recover if this fails? Could the context be clone-able?
+                match BotApiKeyContext::parse(
+                    auth_token.clone(),
+                    &data.oc_config.public_key,
+                    env::now(),
+                ) {
+                    Ok(ctx) => {
+                        let text = [author, [attachments, stickers].concat().join("\n")]
+                            .into_iter()
+                            .filter(|v| !v.is_empty())
+                            .collect::<Vec<String>>()
+                            .join(if message.content.is_empty() {
+                                "\n"
+                            } else {
+                                "\n\n"
+                            });
 
-                    let channel_status = if let Err(err) = res {
-                        error!("Failed to send message to OC :: {:?}", err);
-                        ChannelStatus::ProxyFailed(
-                            "OpenChat bot could not push message to an OC channel.".to_string(),
-                        )
-                    } else {
-                        ChannelStatus::Operational
-                    };
+                        // TODO add recovery mechanism with backpressure for the request.
+                        let res = data
+                            .oc_client
+                            .build_api_key_client(ctx)
+                            .send_message(MessageContent::Text(TextContent { text }))
+                            .execute_async()
+                            .await;
 
-                    data.state
-                        .set_status_for_ds_channel(message.channel_id, channel_status)
-                        .await?;
+                        let channel_status = if let Err(err) = res {
+                            error!("Failed to send message to OC :: {:?}", err);
+                            ChannelStatus::ProxyFailed(
+                                "OpenChat bot could not push message to an OC channel.".to_string(),
+                            )
+                        } else {
+                            ChannelStatus::Operational
+                        };
+
+                        data.state
+                            .set_status_for_ds_channel(message.channel_id, channel_status)
+                            .await?;
+                    }
+                    Err(err) => error!("Failed to obtain OC bot context :: {:?}", err),
                 }
-                Err(err) => error!("Failed to obtain OC bot context :: {:?}", err),
+            } else {
+                warn!(
+                    "Discord message does not contain any data for relaying :: message.id {}",
+                    message.id
+                );
             }
         } else {
             // TODO figure out how to get channel name
             info!(
-                "Cannot proxy message, OpenChat token is not set for Discord channel with id :: {}",
+                "Cannot proxy message, OpenChat token is not set for Discord channel :: channel.id {}",
                 message.channel_id
             );
             data.state


### PR DESCRIPTION
This PR allows the discord bot to send any type of attachment with a defined MIME type, and indicate that a sticker has been sent in the relevant discord channel. This includes images, video, and documents of various types. Any link, e.g. youtube links, are passed as textual messages and will be rendered within the OC UI with a preview component.

This should cover relaying most of the textual Discord communication over to OC for a particular channel that has set a valid OC token.

Threads on Discord are considered channels with their own channel IDs, and therefore any threads spawned from a channel in which communication is relayed to OC, will not also be relayed to OC.

![2025-02-21_17-01](https://github.com/user-attachments/assets/97aae6f1-1c86-4b60-9981-8a1de60eeb1d)
