### PR TITLE
Draft / Suggestion: Bot shared state available via context

### DIFF
--- a/rs/sdk/src/oc_api/client_factory.rs
+++ b/rs/sdk/src/oc_api/client_factory.rs
@@ -18,7 +18,7 @@ impl<R: Runtime> ClientFactory<R> {
         }
     }
 
-    pub fn build_command_client(&self, context: BotCommandContext) -> ClientForCommand<R> {
+    pub fn build_command_client<S>(&self, context: BotCommandContext<S>) -> ClientForCommand<R, S> {
         ClientForCommand::new(self.runtime.clone(), context)
     }
 

--- a/rs/sdk/src/oc_api/client_factory/command.rs
+++ b/rs/sdk/src/oc_api/client_factory/command.rs
@@ -5,21 +5,21 @@ use std::sync::Arc;
 
 mod send_message;
 
-pub struct ClientForCommand<R> {
+pub struct ClientForCommand<R, S> {
     runtime: Arc<R>,
-    context: BotCommandContext,
+    context: BotCommandContext<S>,
 }
 
-impl<R: Runtime> ClientForCommand<R> {
-    pub fn new(runtime: Arc<R>, context: BotCommandContext) -> Self {
+impl<R: Runtime, S> ClientForCommand<R, S> {
+    pub fn new(runtime: Arc<R>, context: BotCommandContext<S>) -> Self {
         ClientForCommand { runtime, context }
     }
 
-    pub fn send_text_message(self, text: String) -> SendMessageBuilder<R> {
+    pub fn send_text_message(self, text: String) -> SendMessageBuilder<R, S> {
         self.send_message(MessageContent::Text(TextContent { text }))
     }
 
-    pub fn send_message(self, content: MessageContent) -> SendMessageBuilder<R> {
+    pub fn send_message(self, content: MessageContent) -> SendMessageBuilder<R, S> {
         SendMessageBuilder::new(self, content)
     }
 }

--- a/rs/sdk/src/oc_api/client_factory/command/send_message.rs
+++ b/rs/sdk/src/oc_api/client_factory/command/send_message.rs
@@ -6,16 +6,16 @@ use crate::types::{CallResult, CanisterId, MessageContent};
 use crate::Runtime;
 use std::sync::Arc;
 
-pub struct SendMessageBuilder<R> {
-    client: ClientForCommand<R>,
+pub struct SendMessageBuilder<R, S> {
+    client: ClientForCommand<R, S>,
     content: MessageContent,
     block_level_markdown: bool,
     finalised: bool,
     initiator_only: bool,
 }
 
-impl<R: Runtime> SendMessageBuilder<R> {
-    pub fn new(client: ClientForCommand<R>, content: MessageContent) -> Self {
+impl<R: Runtime, S> SendMessageBuilder<R, S> {
+    pub fn new(client: ClientForCommand<R, S>, content: MessageContent) -> Self {
         Self {
             client,
             content,
@@ -58,7 +58,7 @@ impl<R: Runtime> SendMessageBuilder<R> {
     }
 }
 
-impl<R: Runtime> ActionArgsBuilder<R> for SendMessageBuilder<R> {
+impl<R: Runtime, S> ActionArgsBuilder<R> for SendMessageBuilder<R, S> {
     type Action = SendMessageAction;
 
     fn runtime(&self) -> Arc<R> {

--- a/rs/sdk/src/types/bot_context.rs
+++ b/rs/sdk/src/types/bot_context.rs
@@ -10,17 +10,23 @@ use crate::utils::base64;
 use super::{ActionScope, BotCommandScope};
 
 #[derive(Debug)]
-pub struct BotCommandContext {
+pub struct BotCommandContext<S> {
     pub token: AuthToken,
     pub bot_id: UserId,
     pub api_gateway: CanisterId,
     pub command: Command,
     pub scope: BotCommandScope,
     pub granted_permissions: BotPermissions,
+    pub shared_state: S,
 }
 
-impl BotCommandContext {
-    pub fn parse(jwt: String, public_key: &str, now: TimestampMillis) -> Result<Self, TokenError> {
+impl<S> BotCommandContext<S> {
+    pub fn parse(
+        jwt: String,
+        public_key: &str,
+        now: TimestampMillis,
+        shared_state: S,
+    ) -> Result<Self, TokenError> {
         let claims = jwt::verify::<Claims<BotActionByCommandClaims>>(&jwt, public_key)
             .map_err(|error| TokenError::Invalid(error.to_string()))?;
 
@@ -37,6 +43,7 @@ impl BotCommandContext {
             scope: claims.scope,
             granted_permissions: claims.granted_permissions.into(),
             api_gateway: claims.bot_api_gateway,
+            shared_state,
         })
     }
 }


### PR DESCRIPTION
Allows bots to hold shared state on the bot context.

Commands would be able to access this state within their `execute` handlers as `ctx.shared_state`. Command definition structs would only need to reference local state.

This would provide SDK support for shared state, though making the type signatures somewhat more complex. For not shared state we'd use unit type `()`.

_(breaking change)_