### PR TITLE
Allow construction of ephemeral messages via builder pattern

### DIFF
--- a/rs/canister/examples/reminder/src/router/commands/delete.rs
+++ b/rs/canister/examples/reminder/src/router/commands/delete.rs
@@ -1,13 +1,11 @@
 use crate::state;
 use async_trait::async_trait;
-use oc_bots_sdk::api::command::{CommandHandler, Message, SuccessResult};
+use oc_bots_sdk::api::command::{CommandHandler, EphemeralMessageBuilder, SuccessResult};
 use oc_bots_sdk::api::definition::{
     BotCommandDefinition, BotCommandParam, BotCommandParamType, IntegerParam,
 };
 use oc_bots_sdk::oc_api::client_factory::ClientFactory;
-use oc_bots_sdk::types::{
-    BotCommandContext, BotCommandScope, BotPermissions, ChatRole, MessageContent, TextContent,
-};
+use oc_bots_sdk::types::{BotCommandContext, BotCommandScope, BotPermissions, ChatRole};
 use oc_bots_sdk_canister::CanisterRuntime;
 use std::sync::LazyLock;
 
@@ -40,16 +38,10 @@ impl CommandHandler<CanisterRuntime> for Delete {
             Err(error) => error,
         };
 
-        // Reply to the initiator with an ephemeral message
-        Ok(SuccessResult {
-            message: Some(Message {
-                id: cxt.scope.message_id().unwrap(),
-                content: MessageContent::Text(TextContent { text }),
-                block_level_markdown: false,
-                finalised: true,
-                ephemeral: true,
-            }),
-        })
+        Ok(EphemeralMessageBuilder::new(cxt)
+            .with_text_content(text)
+            .build()?
+            .into())
     }
 }
 

--- a/rs/canister/examples/reminder/src/router/commands/list.rs
+++ b/rs/canister/examples/reminder/src/router/commands/list.rs
@@ -1,10 +1,8 @@
 use async_trait::async_trait;
-use oc_bots_sdk::api::command::{CommandHandler, Message, SuccessResult};
+use oc_bots_sdk::api::command::{CommandHandler, EphemeralMessageBuilder, SuccessResult};
 use oc_bots_sdk::api::definition::BotCommandDefinition;
 use oc_bots_sdk::oc_api::client_factory::ClientFactory;
-use oc_bots_sdk::types::{
-    BotCommandContext, BotCommandScope, BotPermissions, ChatRole, MessageContent, TextContent,
-};
+use oc_bots_sdk::types::{BotCommandContext, BotCommandScope, BotPermissions, ChatRole};
 use oc_bots_sdk_canister::CanisterRuntime;
 use std::sync::LazyLock;
 
@@ -44,16 +42,10 @@ impl CommandHandler<CanisterRuntime> for List {
             }
         }
 
-        // Reply to the initiator with an ephemeral message
-        Ok(SuccessResult {
-            message: Some(Message {
-                id: cxt.scope.message_id().unwrap(),
-                content: MessageContent::Text(TextContent { text }),
-                block_level_markdown: false,
-                finalised: true,
-                ephemeral: true,
-            }),
-        })
+        Ok(EphemeralMessageBuilder::new(cxt)
+            .with_text_content(text)
+            .build()?
+            .into())
     }
 }
 

--- a/rs/canister/examples/reminder/src/router/commands/remind.rs
+++ b/rs/canister/examples/reminder/src/router/commands/remind.rs
@@ -1,13 +1,11 @@
 use async_trait::async_trait;
 use chrono::DateTime;
-use oc_bots_sdk::api::command::{CommandHandler, Message, SuccessResult};
+use oc_bots_sdk::api::command::{CommandHandler, EphemeralMessageBuilder, SuccessResult};
 use oc_bots_sdk::api::definition::{
     BotCommandDefinition, BotCommandParam, BotCommandParamType, StringParam,
 };
 use oc_bots_sdk::oc_api::client_factory::ClientFactory;
-use oc_bots_sdk::types::{
-    BotCommandContext, BotCommandScope, BotPermissions, ChatRole, MessageContent, TextContent,
-};
+use oc_bots_sdk::types::{BotCommandContext, BotCommandScope, BotPermissions, ChatRole};
 use oc_bots_sdk_canister::{env, CanisterRuntime};
 use std::sync::LazyLock;
 
@@ -85,15 +83,10 @@ impl CommandHandler<CanisterRuntime> for Remind {
         });
 
         // Reply to the initiator with an ephemeral message
-        Ok(SuccessResult {
-            message: Some(Message {
-                id: cxt.scope.message_id().unwrap(),
-                content: MessageContent::Text(TextContent { text }),
-                block_level_markdown: false,
-                finalised: true,
-                ephemeral: true,
-            }),
-        })
+        Ok(EphemeralMessageBuilder::new(cxt)
+            .with_text_content(text)
+            .build()?
+            .into())
     }
 }
 

--- a/rs/sdk/src/api/command.rs
+++ b/rs/sdk/src/api/command.rs
@@ -1,10 +1,10 @@
-use crate::types::{MessageContent, MessageId, UserId};
+use crate::types::{BotCommandContext, MessageContent, MessageId, TextContent, UserId};
 use candid::CandidType;
 use serde::{Deserialize, Serialize};
 
-mod command_handler;
-
 pub use command_handler::{CommandHandler, CommandHandlerRegistry};
+
+mod command_handler;
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
 pub struct Command {
@@ -247,7 +247,7 @@ pub struct Message {
     pub content: MessageContent,
     pub block_level_markdown: bool,
     pub finalised: bool,
-    pub ephemeral: bool,
+    pub(crate) ephemeral: bool,
 }
 
 #[derive(CandidType, Serialize, Deserialize, Clone, Debug)]
@@ -277,4 +277,102 @@ pub enum CanisterError {
 pub struct CommandMeta {
     pub timezone: String, // IANA timezone e.g. "Europe/London"
     pub language: String, // The language selected in OpenChat e.g. "en"
+}
+
+/// Replying with an ephemeral [`Message`]!
+///
+/// Ephemeral messages are not saved to the OC backend, and can only be used
+/// as as a bot's reply sent to the OC UI. Ephemeral messages will only be
+/// visible for the user that initiated interaction with a bot, and they will
+/// dissapear upon UI refresh.
+///
+/// Here's a short example on how to use it:
+/// ```ignore
+/// use oc_bots_sdk::api::command::EphemeralMessageBuilder;
+///
+/// ...
+/// // Somewhere in your bot code, replying to a command...
+/// Ok(EphemeralMessageBuilder::new(ctx)
+///     .with_text_content("Hello, world! This is an ephemeral message, only visible to you.".into())
+///     .build()?
+///     .into())
+/// ```
+///
+/// In this example we're setting textual content for the message, but you
+/// have an option to use [`EphemeralMessageBuilder::with_content`], and provide
+/// any of the supported content types.
+///
+/// Once your ephemeral message is constructed, using `.into()` will transform
+/// the type into a [`SuccessResult`], which can then be wrapped into `Result::Ok`
+/// and returned as a reply for the UI.
+pub struct EphemeralMessageBuilder {
+    context: BotCommandContext,
+    content: Option<MessageContent>,
+    block_level_markdown: bool,
+}
+
+impl EphemeralMessageBuilder {
+    pub fn new(context: BotCommandContext) -> Self {
+        Self {
+            context,
+            content: None,
+            block_level_markdown: false,
+        }
+    }
+
+    /// Sets text content for the ephemeral message. This is a _convenience_
+    /// function.
+    pub fn with_text_content(self, text: String) -> Self {
+        Self {
+            content: Some(MessageContent::Text(TextContent { text })),
+            ..self
+        }
+    }
+
+    /// Set any type of content for the message. Content is required, if it's
+    /// not set, [`EphemeralMessageBuilder::build`] will fail. You may also use
+    /// [`EphemeralMessageBuilder::with_text_content`] to set text content for
+    /// the message.
+    pub fn with_content(self, content: MessageContent) -> Self {
+        Self {
+            content: Some(content),
+            ..self
+        }
+    }
+
+    /// Indicates if your text content contains markdown or not.
+    pub fn with_block_level_markdown(self, block_level_markdown: bool) -> Self {
+        Self {
+            block_level_markdown,
+            ..self
+        }
+    }
+
+    /// Builds a [`Message`] type from the provided data, with the `ephemeral`
+    /// flag set to `true`.
+    pub fn build(self) -> Result<Message, String> {
+        if let Some(content) = self.content {
+            Ok(Message {
+                id: self
+                    .context
+                    .scope
+                    .message_id()
+                    .ok_or_else(|| "Failed to get message id for ephemeral message.")?,
+                content,
+                block_level_markdown: self.block_level_markdown,
+                finalised: true,
+                ephemeral: true,
+            })
+        } else {
+            Err("Ephemeral message content is not set!".into())
+        }
+    }
+}
+
+impl From<Message> for SuccessResult {
+    fn from(message: Message) -> Self {
+        SuccessResult {
+            message: Some(message),
+        }
+    }
 }

--- a/rs/sdk/src/api/command.rs
+++ b/rs/sdk/src/api/command.rs
@@ -282,7 +282,7 @@ pub struct CommandMeta {
 /// Replying with an ephemeral [`Message`]!
 ///
 /// Ephemeral messages are not saved to the OC backend, and can only be used
-/// as as a bot's reply sent to the OC UI. Ephemeral messages will only be
+/// as a bot's reply sent to the OC UI. Ephemeral messages will only be
 /// visible for the user that initiated interaction with a bot, and they will
 /// dissapear upon UI refresh.
 ///

--- a/rs/sdk/src/api/command.rs
+++ b/rs/sdk/src/api/command.rs
@@ -357,7 +357,7 @@ impl EphemeralMessageBuilder {
                     .context
                     .scope
                     .message_id()
-                    .ok_or_else(|| "Failed to get message id for ephemeral message.")?,
+                    .ok_or("Failed to get message id for ephemeral message.")?,
                 content,
                 block_level_markdown: self.block_level_markdown,
                 finalised: true,


### PR DESCRIPTION
Ephemeral messages are constructed via `EphemeralMessageBuilder`, which does not implement any functionality to send the ephemeral message to the OC backend. Ephemeral messages can only be sent to the UI.

This PR also prevents `Message` type construction by filling in the struct properties directly, as the `ephemeral` property has been made available only within the SDK crate.

Added first bit of rustdoc to document the ephemeral message builder functionality.