### PR TITLE
Allow OC token to be cleared

### DIFF
--- a/rs/offchain/examples/discord/README.md
+++ b/rs/offchain/examples/discord/README.md
@@ -10,13 +10,13 @@ A combination of an `OpenChat` and a `Discord` `bot` used to relay messages from
 
 To use this bot right now you can register it within [Discord's developers portal](https://discord.com/developers/applications). Select the **"New Application"** button in the top right corner, and follow the prompts until your app is created.
 
-Once your app is created, under the **"General Information"** you'll find your app ID and public key, and various URL values you may set. It is important **NOT** to set _interactions endpoint url_; since our bot uses WebSockets for communication with Discord servers, setting the interactions url may prevent any data from reaching the bot.
+Once your app is created, under the **"General Information"** you'll find your app ID and public key, and various URL values you may set. It is important **NOT** to set _interactions endpoint url_; since our bot uses WebSockets for communication with Discord servers, setting the _interactions url_ may prevent any data from reaching the bot.
 
 Within the **"Installation"** section you'll find default installation contexts. We'd encourage you to set this up to your preferences; our test settings were to use User and Guild context, with bot scope in the Guild context and "Send Message" permission.
 
 Next, go to the **"Bot"** section for your app, and there you can generate an access token for your bot - make sure you record this value, and keep it secure; do not commit it to version control. The bot consumes this value via `config.toml`, how exactly this value is injected into the config should depend on your deployment process.
 
-Also, while there, make sure to turn on the _Message Content Intent_ which should allow the bot to receive the message content in most messages. One thing to note here is that this setting will make a bot subject to review and approval, once the bot reaches 100+ servers.
+Also, while there, make sure to turn on the _Message Content Intent_ which should allow the bot to receive the message content in most messages. One thing to note here is that this setting will make the bot subject to review and approval once the bot reaches 100+ servers.
 
 **To add the bot to your server** - go back to the **Installation** section from the menu. There you will find a Discord provided install link (or you may register your own), which you can then copy/paste into your browser address bar, and follow the _Add App_ flow.
 
@@ -60,7 +60,7 @@ Once you have the configuration file all set up, place its path into your `rs/.e
 CONFIG_FILE=examples/discord/config.toml
 ```
 
-If this is not set, the bot will by default to `./config.toml` and you might get an error saying config file could not be found. The assumed usefulness of the default value is in production environments where the config is placed next to the built binary.
+If this is not set, the bot will default to `./config.toml` path, and you might get an error saying config file could not be found if it's not there already. The assumed usefulness of the default value is in production environments where the config is placed next to the built binary.
 
 To run the bot you will also need to set configuration values. Please refer to _sample config_ for details about config values and how to set them, and even generate them.
 
@@ -72,11 +72,13 @@ cargo run -p discord-bot
 
 ## How to use
 
-Once the bot(s) is set up on both sides - Discord and OpenChat - you will need to make the connection between the two. This is done by copying the API token for a specific OC channel, and using the `/set_oc_token [oc_api_token arg]` command on the Discord side.
+Once the bot(s) is set up on both sides - Discord and OpenChat - you will need to make the connection between the two. This is done by copying the API key for a specific OC channel, and using the `/connect [oc_api_key arg]` command on the Discord side.
 
-This procedure indicates to the bot that any messages sent within that Discord channel should be also relayed to OpenChat using that specific token. The OC channel API token specifies to which particular OC channel a message should be relayed.
+This procedure indicates to the bot that any messages sent within that Discord channel should also be relayed to OpenChat using that specific token. The OC channel API key specifies to which particular OC channel a message should be relayed.
 
-At this point, messages should freely flow from Discord to OpenChat. You can check the status of the Discord side bot by calling `/status`.
+At this point, messages should freely flow from Discord to OpenChat. You can check the status of the bots by calling `/status`. On the Discord side, `status` provides info about the relay connection, and any potential issues with the relay; on the OpenChat side `status` tells if that channel is connected to any channels on the Discord side.
+
+In case you want to stop relaying messages to OpenChat, or you've made a connection between wrong channels, you can use the `/disconnect` command on the Discord side, which should stop messages from being relayed.
 
 ## Upcoming!
 

--- a/rs/offchain/examples/discord/src/discord.rs
+++ b/rs/offchain/examples/discord/src/discord.rs
@@ -45,8 +45,8 @@ pub async fn init_discord_client(
     let options = poise::FrameworkOptions {
         commands: vec![
             discord_commands::status(),
-            discord_commands::set_oc_token(),
-            discord_commands::clear_oc_token(),
+            discord_commands::connect(),
+            discord_commands::disconnect(),
         ],
         post_command: |ctx| {
             Box::pin(async move {

--- a/rs/offchain/examples/discord/src/discord.rs
+++ b/rs/offchain/examples/discord/src/discord.rs
@@ -43,10 +43,17 @@ pub async fn init_discord_client(
     // Commands are registered on every bot startup; any changes made between
     // restarts will be reflected on the next start-up.
     let options = poise::FrameworkOptions {
-        commands: vec![discord_commands::status(), discord_commands::set_oc_token()],
+        commands: vec![
+            discord_commands::status(),
+            discord_commands::set_oc_token(),
+            discord_commands::clear_oc_token(),
+        ],
         post_command: |ctx| {
             Box::pin(async move {
-                info!("Command processed :: {}", ctx.command().qualified_name);
+                info!(
+                    "Discord :: command processed :: {}",
+                    ctx.command().qualified_name
+                );
             })
         },
         event_handler: |ctx, event, framework, data| {

--- a/rs/offchain/examples/discord/src/discord/commands.rs
+++ b/rs/offchain/examples/discord/src/discord/commands.rs
@@ -1,7 +1,7 @@
 use crate::discord::{Context, Error};
 use crate::shared::{OcChannelKey, RelayLink};
 use oc_bots_sdk::types::TokenError;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 // Set OC token for the channel!
 //
@@ -37,6 +37,30 @@ pub async fn set_oc_token(
                 TokenError::Expired => "Token has expired!",
             }
         }
+    };
+
+    ctx.send(poise::CreateReply::default().ephemeral(true).content(reply))
+        .await?;
+
+    Ok(())
+}
+
+/// Clear OC token!
+///
+/// Removes the previously set OC token within the Discord channel where the
+/// command was called. If no token was
+#[poise::command(slash_command)]
+pub async fn clear_oc_token(ctx: Context<'_>) -> Result<(), Error> {
+    let was_removed = ctx.data().state.remove_relay_link(ctx.channel_id()).await;
+    let reply = if was_removed {
+        info!("Relay link removed for channel :: {}", ctx.channel_id());
+        "OpenChat API token cleared!"
+    } else {
+        warn!(
+            "Attempted to clear token, but OC API token not set for channel :: {}",
+            ctx.channel_id()
+        );
+        "OpenChat API token was not set for this channel!"
     };
 
     ctx.send(poise::CreateReply::default().ephemeral(true).content(reply))

--- a/rs/offchain/examples/discord/src/discord/commands.rs
+++ b/rs/offchain/examples/discord/src/discord/commands.rs
@@ -3,21 +3,31 @@ use crate::shared::{OcChannelKey, RelayLink};
 use oc_bots_sdk::types::TokenError;
 use tracing::{error, info, warn};
 
-// Set OC token for the channel!
-//
-// Token is required to send messages to the OpenChat API. Token is stored
-// specifically for the Discord channel providing it, so you can have different
-// tokens if you'd like to use the bot in multiple Discord channels.
+/// Connect to OC; set OC channel api key!
+///
+/// An api key is required to send messages to the OpenChat API. The api key is
+/// provided directly to the bot using the `/connect` command, and is mapped to
+/// the Discord channel where the command is called.
+///
+/// Api key enables relaying messages only to the OC channel which is the
+/// "owner" of the key. If that key is regenerated on the OC side, relaying
+/// won't work, and you will need to provide the api key again using this
+/// command.
+///
+/// A single OC api key can be given to multiple Discord channels, therefore
+/// aggregating messages from multiple Discord channels within a single OC
+/// channel. A single Discord channel can only be linked to a single OC channel.
 #[poise::command(slash_command)]
-pub async fn set_oc_token(
+pub async fn connect(
     ctx: Context<'_>,
-    #[description = "OpenChat token used to proxy messages to the OpenChat API"] token: String,
+    #[description = "API key of the OpenChat channel where messages should be relayed."]
+    api_key: String,
 ) -> Result<(), Error> {
-    // If token is invalid, this will fail
+    // If api key is invalid, this will fail
     // TODO should we only allow 1:1 Ds to Oc channel message relaying?
-    let reply = match OcChannelKey::from_api_key(token.clone()) {
-        Ok(key) => {
-            let relay_link = RelayLink::new(ctx.channel_id(), key, token);
+    let reply = match OcChannelKey::from_api_key(api_key.clone()) {
+        Ok(oc_channel_key) => {
+            let relay_link = RelayLink::new(ctx.channel_id(), oc_channel_key, api_key);
 
             ctx.data()
                 .state
@@ -25,16 +35,16 @@ pub async fn set_oc_token(
                 .await?;
 
             info!("Relay link initialised for channel :: {}", ctx.channel_id());
-            "OpenChat API token set!"
+            "OpenChat API key set!"
         }
         Err(err) => {
             error!(
-                "Failed to set OpenChat API token for Discord channel :: {:?}",
+                "Failed to set OpenChat API key for Discord channel :: {:?}",
                 err
             );
             match err {
-                TokenError::Invalid(_) => "Token is not valid!",
-                TokenError::Expired => "Token has expired!",
+                TokenError::Invalid(_) => "API key is not valid!",
+                TokenError::Expired => "Provided token has expired!",
             }
         }
     };
@@ -45,22 +55,25 @@ pub async fn set_oc_token(
     Ok(())
 }
 
-/// Clear OC token!
+/// Clear OpenChat API key!
 ///
-/// Removes the previously set OC token within the Discord channel where the
-/// command was called. If no token was
+/// Removes the API key that was previously set for the channel. This will stop
+/// messages from being relayed to the OpenChat API.
+///
+/// Use this command if you've set the wrong API key, or if you want to stop
+/// relaying messages to the OpenChat.
 #[poise::command(slash_command)]
-pub async fn clear_oc_token(ctx: Context<'_>) -> Result<(), Error> {
+pub async fn disconnect(ctx: Context<'_>) -> Result<(), Error> {
     let was_removed = ctx.data().state.remove_relay_link(ctx.channel_id()).await;
     let reply = if was_removed {
         info!("Relay link removed for channel :: {}", ctx.channel_id());
-        "OpenChat API token cleared!"
+        "OpenChat API key cleared!"
     } else {
         warn!(
-            "Attempted to clear token, but OC API token not set for channel :: {}",
+            "Attempted to clear the OC API key, but a key not set for Discord channel :: {}",
             ctx.channel_id()
         );
-        "OpenChat API token was not set for this channel!"
+        "OpenChat API key was not set for this channel!"
     };
 
     ctx.send(poise::CreateReply::default().ephemeral(true).content(reply))
@@ -71,8 +84,10 @@ pub async fn clear_oc_token(ctx: Context<'_>) -> Result<(), Error> {
 
 /// Returns status for the channel!
 ///
-/// If OC token is not provided status will return a message about it, or it will
-/// provide some stats about the messages processed.
+/// This command checks if an OpenChat API key is set for the channel. If it is
+/// set, it will return a message indicating that the key is set; or indicate
+/// that the key is not set. If a message relay failed, it will also indicate
+/// that, and provide some error context.
 #[poise::command(slash_command)]
 pub async fn status(ctx: Context<'_>) -> Result<(), Error> {
     let relay_link = ctx.data().state.get_relay_link(ctx.channel_id()).await;
@@ -80,16 +95,20 @@ pub async fn status(ctx: Context<'_>) -> Result<(), Error> {
     let process_status = || match relay_link {
         Some(RelayLink { error, .. }) => {
             if let Some(reason) = error {
+                // TODO in high volume chats, this may get overwritten quickly.
+                // We should consider a more robust way to store and display
+                // errors. Perhaps a log, that can list last n errors?
                 format!(
-                    "OpenChat token is set for this channel, but message relay failed: {}",
+                    "OpenChat API key is set for this channel, but message relay failed: {}",
                     reason
                 )
             } else {
-                "OpenChat token is set for this channel!".to_string()
+                "OpenChat APi key is set for this channel!".to_string()
             }
         }
-        None => "OpenChat token is not set! Please use the `/set_oc_token` command to set it."
-            .to_string(),
+        None => {
+            "OpenChat API key is not set! Please use the `/connect` command to set it.".to_string()
+        }
     };
 
     ctx.send(

--- a/rs/offchain/examples/discord/src/main.rs
+++ b/rs/offchain/examples/discord/src/main.rs
@@ -11,6 +11,7 @@ use serde_valid::Validate;
 use state::AesKey;
 use std::sync::Arc;
 use tokio::sync::mpsc::channel;
+use tracing::error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -54,18 +55,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let openchat_client =
         crate::openchat::init_openchat_client(&config.openchat, state.clone()).await?;
 
-    // Run bots in their respective threads
-    let (ds_res, oc_res) = tokio::join!(
-        tokio::spawn(async move { discord_client.start().await }),
-        tokio::spawn(crate::openchat::start_openchat_bot(
+    // Run bots, if any of them fails, we log the error and exit.
+    tokio::select! {
+        res = discord_client.start() => {
+            error!("Discord bot failed! :: {:?}", res);
+        },
+        res = crate::openchat::start_openchat_bot(
             Arc::new(openchat_client),
             config.openchat.bot.port,
             rx,
-        )),
-    );
-
-    let _ = ds_res.expect("Discord bot failed!");
-    let _ = oc_res.expect("OpenChat bot failed!");
+        ) => {
+            error!("OpenChat bot failed! :: {:?}", res);
+        },
+    };
 
     Ok(())
 }

--- a/rs/offchain/examples/discord/src/main.rs
+++ b/rs/offchain/examples/discord/src/main.rs
@@ -58,14 +58,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Run bots, if any of them fails, we log the error and exit.
     tokio::select! {
         res = discord_client.start() => {
-            error!("Discord bot failed! :: {:?}", res);
+            if res.is_err() {
+                error!("Discord bot failed! :: {:?}", res);
+            }
         },
         res = crate::openchat::start_openchat_bot(
             Arc::new(openchat_client),
             config.openchat.bot.port,
             rx,
         ) => {
-            error!("OpenChat bot failed! :: {:?}", res);
+            if res.is_err() {
+                error!("OpenChat bot failed! :: {:?}", res);
+            }
         },
     };
 

--- a/rs/offchain/examples/discord/src/openchat.rs
+++ b/rs/offchain/examples/discord/src/openchat.rs
@@ -3,6 +3,7 @@ use crate::errors::BotError;
 use crate::state::BotState;
 use axum::body::Bytes;
 use axum::extract::State;
+use axum::http::header::HeaderMap;
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::Router;
@@ -16,7 +17,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Receiver;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
-use tracing::info;
+use tracing::{error, info};
 pub use types::*;
 
 pub mod commands;
@@ -94,7 +95,27 @@ pub async fn start_openchat_bot(
 }
 
 // Handler for command execution!
-async fn execute_command(State(oc_data): State<Arc<OcData>>, jwt: String) -> (StatusCode, Bytes) {
+async fn execute_command(
+    State(oc_data): State<Arc<OcData>>,
+    headers: HeaderMap,
+) -> (StatusCode, Bytes) {
+    let jwt = if let Some(val) = headers.get("x-oc-jwt") {
+        if let Ok(jwt) = val.to_str() {
+            jwt
+        } else {
+            error!("Failed to parse authorization header! :: {:?}", val);
+            return (
+                StatusCode::BAD_REQUEST,
+                Bytes::from("Failed to parse authorization header!"),
+            );
+        }
+    } else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Bytes::from("No authorization header found!"),
+        );
+    };
+
     let res = oc_data
         .commands
         .execute(&jwt, &oc_data.oc_config.public_key, env::now())
@@ -102,23 +123,38 @@ async fn execute_command(State(oc_data): State<Arc<OcData>>, jwt: String) -> (St
 
     match res {
         CommandResponse::Success(r) => {
+            info!("OpenChat :: command executed successfully!");
             //? should we use unwrap
             (StatusCode::OK, Bytes::from(serde_json::to_vec(&r).unwrap()))
         }
-        CommandResponse::BadRequest(r) => (
-            StatusCode::BAD_REQUEST,
-            Bytes::from(serde_json::to_vec(&r).unwrap()),
-        ),
-        CommandResponse::InternalError(err) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Bytes::from(serde_json::to_vec(&err).unwrap()),
-        ),
-        CommandResponse::TooManyRequests => (StatusCode::TOO_MANY_REQUESTS, Bytes::new()),
+        CommandResponse::BadRequest(r) => {
+            error!("OpenChat :: command failed with bad request :: {:?}", r);
+            (
+                StatusCode::BAD_REQUEST,
+                Bytes::from(serde_json::to_vec(&r).unwrap()),
+            )
+        }
+        CommandResponse::InternalError(err) => {
+            error!(
+                "OpenChat :: command failed with internal error :: {:?}",
+                err
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Bytes::from(format!("{err:?}")),
+            )
+        }
+        CommandResponse::TooManyRequests => {
+            error!("OpenChat :: command failed with _too many_ request!");
+            (StatusCode::TOO_MANY_REQUESTS, Bytes::new())
+        }
     }
 }
 
 // Handler for returning the bot definition!
 async fn bot_definition(State(oc_data): State<Arc<OcData>>, _body: String) -> (StatusCode, Bytes) {
+    info!("OpenChat :: bot definition requested!");
+
     let definition = BotDefinition {
         description: "Bot for proxying messages from Discord to OpenChat".to_string(),
         commands: oc_data.commands.definitions(),

--- a/rs/offchain/examples/discord/src/openchat.rs
+++ b/rs/offchain/examples/discord/src/openchat.rs
@@ -118,7 +118,7 @@ async fn execute_command(
 
     let res = oc_data
         .commands
-        .execute(&jwt, &oc_data.oc_config.public_key, env::now())
+        .execute(jwt, &oc_data.oc_config.public_key, env::now())
         .await;
 
     match res {

--- a/rs/offchain/examples/discord/src/openchat/commands.rs
+++ b/rs/offchain/examples/discord/src/openchat/commands.rs
@@ -7,6 +7,7 @@ use oc_bots_sdk::oc_api::client_factory::ClientFactory;
 use oc_bots_sdk::types::{BotCommandContext, MessageContentInitial};
 use oc_bots_sdk_offchain::AgentRuntime;
 use std::sync::{Arc, LazyLock};
+use tracing::info;
 
 // Status command
 static STATUS_DEFINITION: LazyLock<BotCommandDefinition> = LazyLock::new(Status::definition);
@@ -26,6 +27,8 @@ impl CommandHandler<AgentRuntime> for Status {
         ctx: BotCommandContext,
         _oc_client_factory: &ClientFactory<AgentRuntime>,
     ) -> Result<SuccessResult, String> {
+        info!("OpenChat :: executing status command.");
+
         let key = OcChannelKey::from_bot_context(&ctx);
         let num_links: u32 = self
             .shared_state

--- a/rs/offchain/examples/discord/src/openchat/events.rs
+++ b/rs/offchain/examples/discord/src/openchat/events.rs
@@ -46,7 +46,7 @@ pub async fn handle_openchat_events(
             if !(message.content.is_empty() && attachments.is_empty() && stickers.is_empty()) {
                 // TODO Can we recover if this fails? Could the context be clone-able?
                 match BotApiKeyContext::parse(
-                    relay_link.oc_token.clone(),
+                    relay_link.oc_auth_token.clone(),
                     &data.oc_config.public_key,
                     env::now(),
                 ) {

--- a/rs/offchain/examples/discord/src/shared.rs
+++ b/rs/offchain/examples/discord/src/shared.rs
@@ -64,7 +64,7 @@ pub struct RelayLink {
     // Note that this key can be retrieved from the token, but we are basically
     // caching it to simplify the code.
     pub oc_channel_key: OcChannelKey,
-    pub oc_token: AuthToken,
+    pub oc_auth_token: AuthToken,
     pub error: Option<String>,
 }
 
@@ -73,7 +73,7 @@ impl RelayLink {
         Self {
             ds_channel_id,
             oc_channel_key,
-            oc_token: AuthToken::ApiKey(api_key),
+            oc_auth_token: AuthToken::ApiKey(api_key),
             error: None,
         }
     }

--- a/rs/offchain/examples/discord/src/state.rs
+++ b/rs/offchain/examples/discord/src/state.rs
@@ -200,7 +200,7 @@ mod test {
     use fs::remove_file;
     use oc_bots_sdk::types::AuthToken;
     use poise::serenity_prelude::ChannelId;
-    use std::{env, error::Error};
+    use std::error::Error;
 
     #[tokio::test]
     async fn state_is_encrypted() -> Result<(), Box<dyn Error>> {
@@ -261,6 +261,28 @@ mod test {
         );
         assert_eq!(restored_link.error, None);
 
+        Ok(())
+    }
+
+    // This test should catch errors that may occur when property names of the
+    // state struct are changed, and state is serialised with the old names.
+    // TODO devise a migration mechanism for this case!
+    #[tokio::test]
+    async fn state_decodes_correctly_from_string() -> Result<(), Box<dyn Error>> {
+        let store_str = r#"{
+            "relay_links":{
+                "1338817539941077055":{
+                    "ds_channel_id":"1338817539941077055",
+                    "oc_channel_key":"dzh22-nuaaa-aaaaa-qaaoa-cai",
+                    "oc_auth_token":{
+                        "ApiKey":"eyJnYXRld2F5IjoiY3VqNnUtYzRhYWEtYWFhYWEtcWFhanEtY2FpIiwiYm90X2lkIjoiZWNieHotdHR4bWctM29hZ3QtcHB3MmEiLCJzY29wZSI6eyJDaGF0Ijp7Ikdyb3VwIjoiZHpoMjItbnVhYWEtYWFhYWEtcWFhb2EtY2FpIn19LCJzZWNyZXQiOiIxNjQ1NDMzNjM3NjQ5NzkxMDYxNzUwMTI0MTIwOTIwMDY5NzAzODAiLCJwZXJtaXNzaW9ucyI6eyJtZXNzYWdlIjoxfX0="
+                    },
+                    "error":null
+                }
+            }
+        }"#;
+
+        serde_json::from_str::<PersistData>(store_str)?;
         Ok(())
     }
 }

--- a/rs/offchain/examples/discord/src/state.rs
+++ b/rs/offchain/examples/discord/src/state.rs
@@ -80,6 +80,11 @@ impl BotState {
         self.relay_links.read().await.get(&channel_id).cloned()
     }
 
+    pub async fn remove_relay_link(&self, channel_id: ChannelId) -> bool {
+        let removed_link = self.relay_links.write().await.remove(&channel_id);
+        removed_link.is_some()
+    }
+
     /// Restore previously saved state
     ///
     /// Loads data from the state file, if store path is provided. If the

--- a/rs/offchain/examples/discord/src/state.rs
+++ b/rs/offchain/examples/discord/src/state.rs
@@ -204,8 +204,6 @@ mod test {
 
     #[tokio::test]
     async fn state_is_encrypted() -> Result<(), Box<dyn Error>> {
-        print!("LOC === {:?}", env::current_dir()?);
-
         // This data would be deserialised from the config
         let key = b"-this-is-very-silly--32-bit-key-";
         let store_path_str = "../../target/unit_tests/store.db".to_string();
@@ -230,7 +228,7 @@ mod test {
                 RelayLink {
                     ds_channel_id,
                     oc_channel_key: OcChannelKey::new("this-is-key".into()),
-                    oc_token: AuthToken::ApiKey("this-is-api-key".into()),
+                    oc_auth_token: AuthToken::ApiKey("this-is-api-key".into()),
                     error: None,
                 },
             )
@@ -257,7 +255,10 @@ mod test {
             restored_link.oc_channel_key,
             OcChannelKey::new("this-is-key".into())
         );
-        assert_eq!(restored_link.oc_token.into(), "this-is-api-key".to_string());
+        assert_eq!(
+            restored_link.oc_auth_token.into(),
+            "this-is-api-key".to_string()
+        );
         assert_eq!(restored_link.error, None);
 
         Ok(())


### PR DESCRIPTION
Added a command to disconnect discord and oc channel relay.

Updated how the JWT is fetched from the request in the axum execute command handler, since it's now in the headers.