### PR TITLE
Added tower middleware to extract JWT for offchain bots

### DIFF
--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/rs/Cargo.lock
+++ b/rs/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -439,9 +439,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cached"
@@ -955,6 +955,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tokio",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -1526,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1566,7 +1567,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.21",
  "rustls-pki-types",
@@ -1587,7 +1588,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2383,9 +2384,12 @@ name = "oc_bots_sdk_offchain"
 version = "0.1.0"
 dependencies = [
  "candid",
+ "futures",
+ "http 1.2.0",
  "ic-agent",
  "oc_bots_sdk",
  "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -2912,7 +2916,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",

--- a/rs/Cargo.toml
+++ b/rs/Cargo.toml
@@ -26,7 +26,6 @@ dataurl = "0.1.2"
 dotenv = "0.15.0"
 english-to-cron = "0.1.2" 
 getrandom = { version = "0.2.15", features = ["custom"] }
-hmac-sha256 = { version = "1.1.7", features = ["traits010"] }
 http = "1.1.0"
 ic-agent = "0.39.3"
 ic-cdk = "0.17.0"

--- a/rs/offchain/examples/dice/Cargo.toml
+++ b/rs/offchain/examples/dice/Cargo.toml
@@ -9,7 +9,7 @@ axum = { workspace = true, features = [] }
 clap = { workspace = true, features = ["derive"] }
 dotenv = { workspace = true }
 oc_bots_sdk = { path = "../../../sdk" }
-oc_bots_sdk_offchain = { path = "../../sdk" }
+oc_bots_sdk_offchain = { path = "../../sdk", features = ["tower"] }
 rand = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/rs/offchain/examples/discord/Cargo.toml
+++ b/rs/offchain/examples/discord/Cargo.toml
@@ -10,7 +10,7 @@ axum = { workspace = true }
 dotenv = { workspace = true }
 ic-agent = { workspace = true }
 oc_bots_sdk = { path = "../../../sdk" }
-oc_bots_sdk_offchain = { path = "../../sdk" }
+oc_bots_sdk_offchain = { path = "../../sdk", features = ["tower"] }
 poise = "0.6.1"
 serde = { workspace = true }
 serde_bytes = "0.11.15"
@@ -19,6 +19,7 @@ serde_valid = "1.0.5"
 thiserror = { workspace = true }
 tokio = { version = "1.43.0", features = ["rt-multi-thread", "tracing"] }
 toml = { workspace = true }
+tower = "0.5.2"
 tower-http = { version = "0.6.2", features = ["cors", "trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { workspace = true }

--- a/rs/offchain/examples/llama/Cargo.toml
+++ b/rs/offchain/examples/llama/Cargo.toml
@@ -11,7 +11,7 @@ clap = { workspace = true, features = ["derive"] }
 dotenv = { workspace = true }
 ic-agent = { workspace = true }
 oc_bots_sdk = { path = "../../../sdk" }
-oc_bots_sdk_offchain = { path = "../../sdk" }
+oc_bots_sdk_offchain = { path = "../../sdk", features = ["tower"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/rs/offchain/examples/llama/Cargo.toml
+++ b/rs/offchain/examples/llama/Cargo.toml
@@ -20,3 +20,4 @@ tower-http = { workspace = true, features = ["cors", "trace"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tower = "0.5.2"

--- a/rs/offchain/examples/llama/src/main.rs
+++ b/rs/offchain/examples/llama/src/main.rs
@@ -3,20 +3,21 @@ use crate::config::Config;
 use crate::llm_canister_agent::LlmCanisterAgent;
 use axum::body::Bytes;
 use axum::extract::State;
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::StatusCode;
 use axum::routing::{get, post};
-use axum::Router;
+use axum::{Extension, Router};
 use dotenv::dotenv;
 use oc_bots_sdk::api::command::{CommandHandlerRegistry, CommandResponse};
 use oc_bots_sdk::api::definition::BotDefinition;
 use oc_bots_sdk::oc_api::client_factory::ClientFactory;
 use oc_bots_sdk_offchain::env;
+use oc_bots_sdk_offchain::middleware::tower::{ExtractJwtLayer, OpenChatJwt};
 use oc_bots_sdk_offchain::AgentRuntime;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
-use tracing::{error, info};
+use tracing::info;
 
 mod commands;
 mod config;
@@ -59,6 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let routes = Router::new()
         .route("/execute_command", post(execute_command))
+        .route_layer(ExtractJwtLayer::new())
         .route("/", get(bot_definition))
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive())
@@ -75,28 +77,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn execute_command(
     State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
+    Extension(OpenChatJwt(jwt)): Extension<OpenChatJwt>,
 ) -> (StatusCode, Bytes) {
-    let jwt = if let Some(val) = headers.get("x-oc-jwt") {
-        if let Ok(jwt) = val.to_str() {
-            jwt
-        } else {
-            error!("Failed to parse authorization header! :: {:?}", val);
-            return (
-                StatusCode::BAD_REQUEST,
-                Bytes::from("Failed to parse authorization header!"),
-            );
-        }
-    } else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Bytes::from("No authorization header found!"),
-        );
-    };
-
     match state
         .commands
-        .execute(jwt, &state.oc_public_key, env::now())
+        .execute(&jwt, &state.oc_public_key, env::now())
         .await
     {
         CommandResponse::Success(r) => {

--- a/rs/offchain/examples/llama/src/main.rs
+++ b/rs/offchain/examples/llama/src/main.rs
@@ -15,6 +15,7 @@ use oc_bots_sdk_offchain::middleware::tower::{ExtractJwtLayer, OpenChatJwt};
 use oc_bots_sdk_offchain::AgentRuntime;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::Arc;
+use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
 use tracing::info;
@@ -62,8 +63,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/execute_command", post(execute_command))
         .route_layer(ExtractJwtLayer::new())
         .route("/", get(bot_definition))
-        .layer(TraceLayer::new_for_http())
-        .layer(CorsLayer::permissive())
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(CorsLayer::permissive()),
+        )
         .with_state(Arc::new(app_state));
 
     let socket_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), config.port);

--- a/rs/offchain/sdk/Cargo.toml
+++ b/rs/offchain/sdk/Cargo.toml
@@ -7,6 +7,12 @@ edition = "2021"
 
 [dependencies]
 candid = { workspace = true }
+futures = "0.3.31"
+http.workspace = true
 ic-agent = { workspace = true }
 oc_bots_sdk = { path = "../../sdk" }
 tokio = { workspace = true, features = ["rt"] }
+tower = "0.5.2"
+
+[features]
+tower = []

--- a/rs/offchain/sdk/Cargo.toml
+++ b/rs/offchain/sdk/Cargo.toml
@@ -12,7 +12,7 @@ http.workspace = true
 ic-agent = { workspace = true }
 oc_bots_sdk = { path = "../../sdk" }
 tokio = { workspace = true, features = ["rt"] }
-tower = "0.5.2"
+tower = { version = "0.5.2", optional = true }
 
 [features]
-tower = []
+tower = ["dep:tower"]

--- a/rs/offchain/sdk/src/lib.rs
+++ b/rs/offchain/sdk/src/lib.rs
@@ -4,3 +4,6 @@ pub mod env;
 
 pub use agent_builder::*;
 pub use agent_runtime::AgentRuntime;
+
+#[cfg(feature = "tower")]
+pub mod middleware;

--- a/rs/offchain/sdk/src/middleware/mod.rs
+++ b/rs/offchain/sdk/src/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod tower;

--- a/rs/offchain/sdk/src/middleware/tower.rs
+++ b/rs/offchain/sdk/src/middleware/tower.rs
@@ -1,0 +1,95 @@
+use futures::future::{ready, BoxFuture};
+use http::{header::HeaderName, Request, Response, StatusCode};
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+#[derive(Clone, Debug)]
+pub struct OpenChatJwt(pub String);
+
+impl OpenChatJwt {
+    pub(crate) fn new(jwt: String) -> Self {
+        Self(jwt)
+    }
+}
+
+#[derive(Clone)]
+pub struct ExtractJwtLayer {
+    header_name: HeaderName,
+}
+
+impl ExtractJwtLayer {
+    pub fn new() -> Self {
+        Self {
+            header_name: HeaderName::from_static("x-oc-jwt"),
+        }
+    }
+}
+
+impl Default for ExtractJwtLayer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<S> Layer<S> for ExtractJwtLayer {
+    type Service = ExtractJwtMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ExtractJwtMiddleware {
+            inner,
+            header_name: self.header_name.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ExtractJwtMiddleware<S> {
+    inner: S,
+    header_name: HeaderName,
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for ExtractJwtMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Error: Send + 'static,
+    S::Future: Send + 'static,
+    ResBody: Send + Default + From<&'static str> + 'static,
+{
+    type Response = Response<ResBody>;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        let header_value = req
+            .headers()
+            .get(&self.header_name)
+            .ok_or("No authorization header found!")
+            .and_then(|v| v.to_str().map_err(|_| "Failed to parse JWT header!"))
+            .map(String::from);
+
+        match header_value {
+            Ok(jwt) => {
+                req.extensions_mut().insert(OpenChatJwt::new(jwt));
+            }
+            Err(reason) => {
+                let response = Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(ResBody::from(reason))
+                    .unwrap();
+
+                return Box::pin(ready(Ok(response)));
+            }
+        }
+
+        let fut = self.inner.call(req);
+
+        Box::pin(async move {
+            let response = fut.await?;
+            Ok(response)
+        })
+    }
+}


### PR DESCRIPTION
JWT is extracted via middleware, added to the request extensions, and then extracted as a request handler argument. This middleware should only be applied to the `execute_command` route. The base `route` should remain public.

This functionality is added with `feature = ["tower"]`. It can be applied to any Rust server implemented on top of `tower`, for example `axum`.