### PR TITLE
Fix the loader for greet bot

### DIFF
--- a/rs/canister/examples/greet/loader/src/lib.rs
+++ b/rs/canister/examples/greet/loader/src/lib.rs
@@ -52,6 +52,12 @@ pub async fn run(config: Config) -> Result<(), Box<dyn Error + Send + Sync>> {
         }
     }
 
+    // Send any remaining jokes
+    if !jokes.is_empty() {
+        let args = insert_jokes::Args { jokes };
+        make_update_call(&agent, &config.greet_bot_canister_id, "insert_jokes", &args).await?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Fix an issue where the loader wouldn't insert jokes in greet_bot if there is less than 10,000 jokes contained in the csv file