### PR TITLE
feat(ts/examples): add FAQ bot example (RAG over local corpus)

### DIFF
--- a/ts/examples/faq/.env.example
+++ b/ts/examples/faq/.env.example
@@ -1,0 +1,26 @@
+# OpenChat integration (same as other ts/examples)
+OC_PUBLIC=
+IDENTITY_PRIVATE=
+IC_HOST=https://icp-api.io
+STORAGE_INDEX_CANISTER=
+
+# Server
+PORT=3000
+
+# FAQ bot
+FAQ_SOURCE=./data/faq.md
+FAQ_INDEX=./data/faq.db
+TOP_K=4
+
+# Provider selection (default: hf)
+EMBEDDING_PROVIDER=hf
+LLM_PROVIDER=hf
+
+# Hugging Face Inference API (free tier)
+HF_TOKEN=
+HF_EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
+HF_LLM_MODEL=HuggingFaceH4/zephyr-7b-beta
+
+# Alternative: Groq free tier (set LLM_PROVIDER=groq)
+GROQ_API_KEY=
+GROQ_MODEL=llama-3.1-8b-instant

--- a/ts/examples/faq/.gitignore
+++ b/ts/examples/faq/.gitignore
@@ -1,2 +1,5 @@
 # Generated FAQ vector index (rebuild with `npm run ingest`)
 data/*.db
+data/*.db-wal
+data/*.db-shm
+data/*.db-journal

--- a/ts/examples/faq/.gitignore
+++ b/ts/examples/faq/.gitignore
@@ -1,0 +1,2 @@
+# Generated FAQ vector index (rebuild with `npm run ingest`)
+data/*.db

--- a/ts/examples/faq/README.md
+++ b/ts/examples/faq/README.md
@@ -38,18 +38,21 @@ ts/examples/faq/
 
 ## Setup
 
+All commands assume you start from the repository root.
+
 1. Build the shared TypeScript SDK once:
 
    ```sh
-   cd ../../library
+   cd ts/library
    npm install
    npm run build
-   cd -
+   cd ../..
    ```
 
-2. Install this example's dependencies:
+2. Switch into this example and install its dependencies:
 
    ```sh
+   cd ts/examples/faq
    npm install
    ```
 
@@ -80,7 +83,7 @@ ts/examples/faq/
 
 Drop any markdown file in `data/`, point `FAQ_SOURCE` at it, and re-run `npm run ingest`.
 Chunks are separated by blank lines, so shape your source accordingly (one Q+A pair per
-chunk works well).
+chunk works well). Chunks that are only markdown headings are skipped automatically.
 
 ## Provider swap
 

--- a/ts/examples/faq/README.md
+++ b/ts/examples/faq/README.md
@@ -107,3 +107,26 @@ Additional providers can be added by extending the switch in `src/rag/{embed,llm
 - **Preferred provider defaults.** Defaulting to Hugging Face free tier to keep the
   example free to try; open to changing the default if the project has a preferred
   provider.
+
+
+## Evaluation
+
+A small smoke-grade evaluation script is included to pin retrieval quality.
+
+`data/eval.jsonl` holds (query, expected_keyword) pairs. The script embeds each
+query, retrieves the top-k chunks via `sqlite-vec`, and reports hit rate plus
+retrieval latency:
+
+```sh
+npm run ingest      # build the index from data/faq.md
+npm run eval        # run the eval set against the index
+```
+
+A "hit" means the expected keyword appears (case-insensitive) somewhere in the
+retrieved chunk. This is coarse on purpose: it pins regressions without
+requiring chunk-id stability across re-ingests. Replace `data/eval.jsonl` with
+your own queries when you swap in your real FAQ corpus.
+
+The script reads `FAQ_EVAL` (default `./data/eval.jsonl`), `FAQ_INDEX`
+(default `./data/faq.db`), and `FAQ_EVAL_K` (default `3`). It exits non-zero if
+any query misses entirely, so it can run as a CI smoke test.

--- a/ts/examples/faq/README.md
+++ b/ts/examples/faq/README.md
@@ -83,7 +83,7 @@ All commands assume you start from the repository root.
 
 Drop any markdown file in `data/`, point `FAQ_SOURCE` at it, and re-run `npm run ingest`.
 Chunks are separated by blank lines, so shape your source accordingly (one Q+A pair per
-chunk works well). Chunks that are only markdown headings are skipped automatically.
+chunk works well). Chunks that are only Markdown headings are skipped automatically.
 
 ## Provider swap
 

--- a/ts/examples/faq/README.md
+++ b/ts/examples/faq/README.md
@@ -1,0 +1,106 @@
+# FAQ Bot (TypeScript example)
+
+A minimal retrieval-augmented FAQ bot for OpenChat. Users run `/ask <question>`; the bot
+embeds the question, retrieves the most relevant chunks from a local FAQ corpus via
+[`sqlite-vec`](https://github.com/asg017/sqlite-vec), and asks a configurable LLM to
+compose a grounded answer.
+
+Addresses [open-chat-labs/open-chat-bots#158](https://github.com/open-chat-labs/open-chat-bots/issues/158).
+
+## What it demonstrates
+
+- Command bot skeleton (same Express + JWT middleware pattern as `ts/examples/openai`).
+- A small RAG loop (`src/rag/{embed,llm,store}.ts`) that is easy to swap out.
+- An ingest script (`scripts/ingest.ts`) that builds the `sqlite-vec` index from a
+  plain markdown source, so the FAQ corpus is trivial to replace.
+
+## Layout
+
+```
+ts/examples/faq/
+├── data/faq.md          # seed corpus (replace with your own FAQ)
+├── scripts/ingest.ts    # markdown -> chunks -> embeddings -> sqlite-vec index
+└── src/
+    ├── server.ts        # Express entry
+    ├── app.ts           # /execute_command, /bot_definition
+    ├── factory.ts       # BotClientFactory
+    ├── middleware/botclient.ts
+    ├── rag/
+    │   ├── embed.ts     # embedding provider (default: Hugging Face)
+    │   ├── llm.ts       # chat provider (default: Hugging Face; also Groq)
+    │   └── store.ts     # sqlite-vec init / insert / search
+    └── handlers/
+        ├── schema.ts    # /ask command definition
+        ├── executeCommand.ts
+        ├── success.ts
+        └── ask.ts       # RAG handler
+```
+
+## Setup
+
+1. Build the shared TypeScript SDK once:
+
+   ```sh
+   cd ../../library
+   npm install
+   npm run build
+   cd -
+   ```
+
+2. Install this example's dependencies:
+
+   ```sh
+   npm install
+   ```
+
+3. Copy `.env.example` to `.env` and fill in the OpenChat values
+   (`OC_PUBLIC`, `IDENTITY_PRIVATE`, `IC_HOST`, `STORAGE_INDEX_CANISTER`) and a provider
+   token. By default the bot uses the Hugging Face Inference API free tier, so set
+   `HF_TOKEN`. To use Groq instead, set `LLM_PROVIDER=groq` and `GROQ_API_KEY`.
+
+4. Build the FAQ index:
+
+   ```sh
+   npm run ingest
+   ```
+
+   This reads `FAQ_SOURCE` (default `./data/faq.md`), splits it on blank lines, embeds
+   each chunk, and writes `FAQ_INDEX` (default `./data/faq.db`).
+
+5. Run the bot:
+
+   ```sh
+   npm run dev
+   ```
+
+   Register it against your local OpenChat instance with `/register_bot` (see the repo
+   root [`GETSTARTED.md`](../../../GETSTARTED.md)).
+
+## Replacing the FAQ corpus
+
+Drop any markdown file in `data/`, point `FAQ_SOURCE` at it, and re-run `npm run ingest`.
+Chunks are separated by blank lines, so shape your source accordingly (one Q+A pair per
+chunk works well).
+
+## Provider swap
+
+Both embedding and chat providers are selected by env var:
+
+| Env var | Values | Notes |
+| --- | --- | --- |
+| `EMBEDDING_PROVIDER` | `hf` | Hugging Face Inference API, default model `sentence-transformers/all-MiniLM-L6-v2` |
+| `LLM_PROVIDER` | `hf`, `groq` | `hf` uses the Inference API chat endpoint; `groq` uses the Groq OpenAI-compatible API |
+
+Additional providers can be added by extending the switch in `src/rag/{embed,llm}.ts`.
+
+## Open questions for maintainers
+
+- **FAQ data source.** The bundled `data/faq.md` is placeholder content. Happy to swap
+  it for an authoritative source (OpenChat docs, a curated Q&A set, or a live feed) on
+  request.
+- **Deployment shape.** Published as an off-chain Node bot for now, matching the other
+  `ts/examples`. If an on-chain (canister) variant is preferred, that would be a larger
+  rework.
+- **Preferred provider defaults.** Defaulting to Hugging Face free tier to keep the
+  example free to try; open to changing the default if the project has a preferred
+  provider.

--- a/ts/examples/faq/data/eval.jsonl
+++ b/ts/examples/faq/data/eval.jsonl
@@ -1,0 +1,6 @@
+{"query": "What is OpenChat?", "expected_keyword": "decentralized chat platform"}
+{"query": "How do I sign in?", "expected_keyword": "Internet Identity"}
+{"query": "What types of bots exist?", "expected_keyword": "command bots"}
+{"query": "How do bots authenticate with OpenChat?", "expected_keyword": "JWT"}
+{"query": "How can I test a bot locally?", "expected_keyword": "register_bot"}
+{"query": "Where do I register a bot?", "expected_keyword": "register_bot"}

--- a/ts/examples/faq/data/faq.md
+++ b/ts/examples/faq/data/faq.md
@@ -1,0 +1,51 @@
+# OpenChat FAQ (sample)
+
+This file is a placeholder FAQ corpus used to seed the bot's vector index.
+Replace or extend it with the real FAQ content you want the bot to answer from.
+
+## What is OpenChat?
+
+OpenChat is a fully decentralized chat platform built on the Internet Computer (ICP).
+Every message, user, and community lives on-chain. Governance is handled by an SNS DAO,
+and the platform has no central server operator.
+
+## How do I get started on OpenChat?
+
+Visit https://oc.app and sign in with an Internet Identity, an email passkey, or another
+supported authentication option. Once signed in you can join communities, start direct
+chats, and create your own groups.
+
+## What are OpenChat bots?
+
+OpenChat bots are off-chain or on-chain programs that can send and receive messages in
+OpenChat chats on behalf of a bot principal. A bot is registered by publishing a bot
+definition and associating it with a chat or community.
+
+## What kinds of bots can I build?
+
+There are three main kinds: command bots (triggered by a slash command), integration
+bots (respond to webhooks or external events), and autonomous bots (subscribe to chat
+events and react on their own).
+
+## How does bot authentication work?
+
+The OpenChat backend signs a short-lived JWT with its private key. Your bot verifies the
+JWT with the OpenChat public key using the provided SDK. No additional secret sharing is
+required on the bot side.
+
+## How do I test a bot locally?
+
+Run the OpenChat backend locally via the open-chat repository, then register your bot
+with /register_bot in your local instance. Point the bot's OC_PUBLIC, IC_HOST, and
+IDENTITY_PRIVATE env vars at the local setup.
+
+## How do I publish a bot for real users?
+
+Publishing a bot to the main OpenChat deployment requires an SNS DAO proposal that
+approves the bot principal and its definition. Until the proposal passes, the bot can
+still be used in private test communities.
+
+## Where is the SDK for TypeScript bots?
+
+The TypeScript bot client library lives under ts/library in the open-chat-bots repo and
+is published as @open-ic/openchat-botclient-ts. See ts/examples for reference bots.

--- a/ts/examples/faq/package.json
+++ b/ts/examples/faq/package.json
@@ -6,7 +6,8 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "dev": "nodemon --exec ts-node ./src/server.ts",
-    "ingest": "ts-node ./scripts/ingest.ts"
+    "ingest": "ts-node ./scripts/ingest.ts",
+    "eval": "ts-node ./scripts/eval.ts"
   },
   "author": "",
   "license": "ISC",

--- a/ts/examples/faq/package.json
+++ b/ts/examples/faq/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@open-ic/faq_bot",
   "version": "0.1.0",
-  "main": "index.js",
+  "main": "dist/server.js",
   "scripts": {
     "build": "tsc",
     "start": "node dist/server.js",

--- a/ts/examples/faq/package.json
+++ b/ts/examples/faq/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@open-ic/faq_bot",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "dev": "nodemon --exec ts-node ./src/server.ts",
+    "ingest": "ts-node ./scripts/ingest.ts"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "OpenChat FAQ bot example: retrieval-augmented Q&A over a local FAQ corpus using sqlite-vec and a configurable embedding/LLM provider",
+  "dependencies": {
+    "@dfinity/identity-secp256k1": "^2.2.0",
+    "@open-ic/openchat-botclient-ts": "../../library",
+    "better-sqlite3": "^11.7.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.1",
+    "node-fetch": "^3.3.2",
+    "sqlite-vec": "^0.1.6"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.10.5",
+    "nodemon": "^3.1.9",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/ts/examples/faq/package.json
+++ b/ts/examples/faq/package.json
@@ -18,7 +18,6 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
-    "node-fetch": "^3.3.2",
     "sqlite-vec": "^0.1.6"
   },
   "devDependencies": {

--- a/ts/examples/faq/scripts/eval.ts
+++ b/ts/examples/faq/scripts/eval.ts
@@ -1,0 +1,100 @@
+/**
+ * Smoke-grade RAG evaluation for the FAQ bot.
+ *
+ * Reads (query, expected_keyword) pairs from FAQ_EVAL (default
+ * ./data/eval.jsonl), runs each query against the configured embedding
+ * provider + sqlite-vec index, and reports top-1 / top-k hit rate plus
+ * mean retrieval latency.
+ *
+ * A "hit" means the expected keyword appears (case-insensitive) somewhere
+ * in the retrieved chunk text. This is intentionally coarse — it pins
+ * regressions in retrieval quality without requiring chunk-id stability
+ * across re-ingests.
+ *
+ * Usage: npm run eval
+ *
+ * Env:
+ *   FAQ_EVAL    eval set path  (default ./data/eval.jsonl)
+ *   FAQ_INDEX   sqlite-vec db  (default ./data/faq.db)
+ *   FAQ_EVAL_K  top-k for hit rate (default 3)
+ */
+import "dotenv/config";
+import fs from "fs";
+import path from "path";
+import { embed } from "../src/rag/embed";
+import { openIndex, search } from "../src/rag/store";
+
+interface EvalCase {
+  query: string;
+  expected_keyword: string;
+}
+
+async function main() {
+  const evalPath = path.resolve(process.cwd(), process.env.FAQ_EVAL || "./data/eval.jsonl");
+  const indexPath = path.resolve(process.cwd(), process.env.FAQ_INDEX || "./data/faq.db");
+  const k = parseInt(process.env.FAQ_EVAL_K || "3", 10);
+
+  if (!fs.existsSync(evalPath)) {
+    throw new Error(`Eval set not found: ${evalPath}`);
+  }
+  if (!fs.existsSync(indexPath)) {
+    throw new Error(`Index not found: ${indexPath}. Run "npm run ingest" first.`);
+  }
+
+  const cases: EvalCase[] = fs
+    .readFileSync(evalPath, "utf8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l));
+
+  if (cases.length === 0) {
+    throw new Error("Eval set is empty");
+  }
+
+  const db = openIndex(indexPath);
+  let top1Hits = 0;
+  let topKHits = 0;
+  const latenciesMs: number[] = [];
+
+  try {
+    for (const c of cases) {
+      const start = Date.now();
+      const queryVec = await embed(c.query);
+      const results = search(db, queryVec, k);
+      latenciesMs.push(Date.now() - start);
+
+      const expected = c.expected_keyword.toLowerCase();
+      const top1Hit = results.length > 0 && results[0].text.toLowerCase().includes(expected);
+      const topKHit = results.some((r) => r.text.toLowerCase().includes(expected));
+
+      if (top1Hit) top1Hits++;
+      if (topKHit) topKHits++;
+
+      const status = topKHit ? (top1Hit ? "PASS@1  " : `PASS@${k}  `) : "FAIL    ";
+      console.log(`${status}${c.query}`);
+    }
+  } finally {
+    db.close();
+  }
+
+  const n = cases.length;
+  const avgMs = latenciesMs.reduce((a, b) => a + b, 0) / n;
+  const sorted = [...latenciesMs].sort((a, b) => a - b);
+  const p50 = sorted[Math.floor(n * 0.5)];
+  const p95 = sorted[Math.min(Math.floor(n * 0.95), n - 1)];
+
+  console.log("");
+  console.log(`Results: ${n} queries, top-${k}`);
+  console.log(`  top-1   hit rate: ${top1Hits}/${n}  = ${((top1Hits / n) * 100).toFixed(1)}%`);
+  console.log(`  top-${k}   hit rate: ${topKHits}/${n}  = ${((topKHits / n) * 100).toFixed(1)}%`);
+  console.log(`  latency p50/p95/avg: ${p50} / ${p95} / ${avgMs.toFixed(0)} ms`);
+
+  if (topKHits < n) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/examples/faq/scripts/eval.ts
+++ b/ts/examples/faq/scripts/eval.ts
@@ -4,7 +4,8 @@
  * Reads (query, expected_keyword) pairs from FAQ_EVAL (default
  * ./data/eval.jsonl), runs each query against the configured embedding
  * provider + sqlite-vec index, and reports top-1 / top-k hit rate plus
- * mean retrieval latency.
+ * embedding-call and sqlite-vec search latencies separately so the
+ * remote-API time does not get reported as retrieval latency.
  *
  * A "hit" means the expected keyword appears (case-insensitive) somewhere
  * in the retrieved chunk text. This is intentionally coarse — it pins
@@ -27,6 +28,15 @@ import { openIndex, search } from "../src/rag/store";
 interface EvalCase {
   query: string;
   expected_keyword: string;
+}
+
+function summarize(label: string, samples: number[]): void {
+  if (samples.length === 0) return;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const avg = samples.reduce((a, b) => a + b, 0) / samples.length;
+  const p50 = sorted[Math.floor(samples.length * 0.5)];
+  const p95 = sorted[Math.min(Math.floor(samples.length * 0.95), samples.length - 1)];
+  console.log(`  ${label} p50/p95/avg: ${p50} / ${p95} / ${avg.toFixed(0)} ms`);
 }
 
 async function main() {
@@ -54,14 +64,18 @@ async function main() {
   const db = openIndex(indexPath);
   let top1Hits = 0;
   let topKHits = 0;
-  const latenciesMs: number[] = [];
+  const embedMs: number[] = [];
+  const searchMs: number[] = [];
 
   try {
     for (const c of cases) {
-      const start = Date.now();
+      const embedStart = Date.now();
       const queryVec = await embed(c.query);
+      embedMs.push(Date.now() - embedStart);
+
+      const searchStart = Date.now();
       const results = search(db, queryVec, k);
-      latenciesMs.push(Date.now() - start);
+      searchMs.push(Date.now() - searchStart);
 
       const expected = c.expected_keyword.toLowerCase();
       const top1Hit = results.length > 0 && results[0].text.toLowerCase().includes(expected);
@@ -78,16 +92,12 @@ async function main() {
   }
 
   const n = cases.length;
-  const avgMs = latenciesMs.reduce((a, b) => a + b, 0) / n;
-  const sorted = [...latenciesMs].sort((a, b) => a - b);
-  const p50 = sorted[Math.floor(n * 0.5)];
-  const p95 = sorted[Math.min(Math.floor(n * 0.95), n - 1)];
-
   console.log("");
   console.log(`Results: ${n} queries, top-${k}`);
   console.log(`  top-1   hit rate: ${top1Hits}/${n}  = ${((top1Hits / n) * 100).toFixed(1)}%`);
   console.log(`  top-${k}   hit rate: ${topKHits}/${n}  = ${((topKHits / n) * 100).toFixed(1)}%`);
-  console.log(`  latency p50/p95/avg: ${p50} / ${p95} / ${avgMs.toFixed(0)} ms`);
+  summarize("embed   latency", embedMs);
+  summarize("search  latency", searchMs);
 
   if (topKHits < n) {
     process.exitCode = 1;

--- a/ts/examples/faq/scripts/ingest.ts
+++ b/ts/examples/faq/scripts/ingest.ts
@@ -46,15 +46,18 @@ async function main() {
   }
   const db = initIndex(indexPath, dim);
 
-  insertChunk(db, chunks[0], first);
-  for (let i = 1; i < chunks.length; i++) {
-    const vec = await embed(chunks[i]);
-    insertChunk(db, chunks[i], vec);
-    if ((i + 1) % 10 === 0) {
-      console.log(`  ${i + 1}/${chunks.length} embedded`);
+  try {
+    insertChunk(db, chunks[0], first);
+    for (let i = 1; i < chunks.length; i++) {
+      const vec = await embed(chunks[i]);
+      insertChunk(db, chunks[i], vec);
+      if ((i + 1) % 10 === 0) {
+        console.log(`  ${i + 1}/${chunks.length} embedded`);
+      }
     }
+  } finally {
+    db.close();
   }
-  db.close();
   console.log(`Index written to ${indexPath}`);
 }
 

--- a/ts/examples/faq/scripts/ingest.ts
+++ b/ts/examples/faq/scripts/ingest.ts
@@ -3,14 +3,20 @@
  *
  * Usage: npm run ingest
  *
- * Splits FAQ_SOURCE on blank lines into chunks, embeds each chunk via the
- * configured EMBEDDING_PROVIDER, and writes them to FAQ_INDEX (sqlite-vec).
+ * Splits FAQ_SOURCE on blank lines into chunks, discards chunks that are
+ * only markdown headings, embeds each remaining chunk via the configured
+ * EMBEDDING_PROVIDER, and writes them to FAQ_INDEX (sqlite-vec).
  */
 import "dotenv/config";
 import fs from "fs";
 import path from "path";
 import { embed } from "../src/rag/embed";
 import { initIndex, insertChunk } from "../src/rag/store";
+
+function isHeadingOnly(chunk: string): boolean {
+  const lines = chunk.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+  return lines.length > 0 && lines.every((l) => /^#{1,6}\s/.test(l));
+}
 
 async function main() {
   const sourcePath = path.resolve(process.cwd(), process.env.FAQ_SOURCE || "./data/faq.md");
@@ -24,7 +30,7 @@ async function main() {
   const chunks = raw
     .split(/\n\s*\n/)
     .map((c) => c.trim())
-    .filter((c) => c.length > 0);
+    .filter((c) => c.length > 0 && !isHeadingOnly(c));
 
   if (chunks.length === 0) {
     throw new Error("No chunks found in FAQ source");

--- a/ts/examples/faq/scripts/ingest.ts
+++ b/ts/examples/faq/scripts/ingest.ts
@@ -1,0 +1,58 @@
+/**
+ * Build the FAQ vector index from a markdown source.
+ *
+ * Usage: npm run ingest
+ *
+ * Splits FAQ_SOURCE on blank lines into chunks, embeds each chunk via the
+ * configured EMBEDDING_PROVIDER, and writes them to FAQ_INDEX (sqlite-vec).
+ */
+import "dotenv/config";
+import fs from "fs";
+import path from "path";
+import { embed } from "../src/rag/embed";
+import { initIndex, insertChunk } from "../src/rag/store";
+
+async function main() {
+  const sourcePath = path.resolve(process.cwd(), process.env.FAQ_SOURCE || "./data/faq.md");
+  const indexPath = path.resolve(process.cwd(), process.env.FAQ_INDEX || "./data/faq.db");
+
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(`FAQ source not found: ${sourcePath}`);
+  }
+
+  const raw = fs.readFileSync(sourcePath, "utf8");
+  const chunks = raw
+    .split(/\n\s*\n/)
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
+
+  if (chunks.length === 0) {
+    throw new Error("No chunks found in FAQ source");
+  }
+
+  console.log(`Embedding ${chunks.length} chunks from ${sourcePath}...`);
+  const first = await embed(chunks[0]);
+  const dim = first.length;
+  console.log(`Embedding dimension: ${dim}`);
+
+  if (fs.existsSync(indexPath)) {
+    fs.unlinkSync(indexPath);
+  }
+  const db = initIndex(indexPath, dim);
+
+  insertChunk(db, chunks[0], first);
+  for (let i = 1; i < chunks.length; i++) {
+    const vec = await embed(chunks[i]);
+    insertChunk(db, chunks[i], vec);
+    if ((i + 1) % 10 === 0) {
+      console.log(`  ${i + 1}/${chunks.length} embedded`);
+    }
+  }
+  db.close();
+  console.log(`Index written to ${indexPath}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/ts/examples/faq/scripts/ingest.ts
+++ b/ts/examples/faq/scripts/ingest.ts
@@ -3,9 +3,14 @@
  *
  * Usage: npm run ingest
  *
- * Splits FAQ_SOURCE on blank lines into chunks, discards chunks that are
- * only markdown headings, embeds each remaining chunk via the configured
- * EMBEDDING_PROVIDER, and writes them to FAQ_INDEX (sqlite-vec).
+ * Splits FAQ_SOURCE on blank lines into chunks. Heading-only chunks (e.g.
+ * `## Question`) are merged into the following content chunk so question
+ * wording stays in the embedded text. Each resulting chunk is embedded via
+ * the configured EMBEDDING_PROVIDER and written to FAQ_INDEX (sqlite-vec).
+ *
+ * Writes to FAQ_INDEX.tmp first and atomically renames into place on
+ * success, so a mid-build failure leaves the previous index untouched
+ * rather than partially overwritten.
  */
 import "dotenv/config";
 import fs from "fs";
@@ -18,19 +23,40 @@ function isHeadingOnly(chunk: string): boolean {
   return lines.length > 0 && lines.every((l) => /^#{1,6}\s/.test(l));
 }
 
+function splitChunks(raw: string): string[] {
+  const rawChunks = raw
+    .split(/\n\s*\n/)
+    .map((c) => c.trim())
+    .filter((c) => c.length > 0);
+
+  const chunks: string[] = [];
+  let pendingHeading = "";
+  for (const c of rawChunks) {
+    if (isHeadingOnly(c)) {
+      // Stack consecutive heading-only chunks (e.g. h1 followed by h2) so the
+      // most specific heading is preserved with the content that follows.
+      pendingHeading = pendingHeading ? `${pendingHeading}\n${c}` : c;
+    } else {
+      chunks.push(pendingHeading ? `${pendingHeading}\n\n${c}` : c);
+      pendingHeading = "";
+    }
+  }
+  // Trailing heading with no content: drop. A heading by itself carries no
+  // answer text, so embedding it alone is not useful for retrieval.
+  return chunks;
+}
+
 async function main() {
   const sourcePath = path.resolve(process.cwd(), process.env.FAQ_SOURCE || "./data/faq.md");
   const indexPath = path.resolve(process.cwd(), process.env.FAQ_INDEX || "./data/faq.db");
+  const tmpPath = `${indexPath}.tmp`;
 
   if (!fs.existsSync(sourcePath)) {
     throw new Error(`FAQ source not found: ${sourcePath}`);
   }
 
   const raw = fs.readFileSync(sourcePath, "utf8");
-  const chunks = raw
-    .split(/\n\s*\n/)
-    .map((c) => c.trim())
-    .filter((c) => c.length > 0 && !isHeadingOnly(c));
+  const chunks = splitChunks(raw);
 
   if (chunks.length === 0) {
     throw new Error("No chunks found in FAQ source");
@@ -41,10 +67,12 @@ async function main() {
   const dim = first.length;
   console.log(`Embedding dimension: ${dim}`);
 
-  if (fs.existsSync(indexPath)) {
-    fs.unlinkSync(indexPath);
+  // Build into a temp file so a mid-build failure does not corrupt the
+  // existing index. Rename atomically once all chunks are persisted.
+  if (fs.existsSync(tmpPath)) {
+    fs.unlinkSync(tmpPath);
   }
-  const db = initIndex(indexPath, dim);
+  const db = initIndex(tmpPath, dim);
 
   try {
     insertChunk(db, chunks[0], first);
@@ -55,9 +83,14 @@ async function main() {
         console.log(`  ${i + 1}/${chunks.length} embedded`);
       }
     }
-  } finally {
+  } catch (err) {
     db.close();
+    if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+    throw err;
   }
+  db.close();
+
+  fs.renameSync(tmpPath, indexPath);
   console.log(`Index written to ${indexPath}`);
 }
 

--- a/ts/examples/faq/src/app.ts
+++ b/ts/examples/faq/src/app.ts
@@ -1,0 +1,15 @@
+import cors from "cors";
+import express from "express";
+import { factory } from "./factory";
+import executeCommand from "./handlers/executeCommand";
+import schema from "./handlers/schema";
+import { createCommandChatClient } from "./middleware/botclient";
+
+const app = express();
+
+app.use(cors());
+app.post("/execute_command", express.text(), createCommandChatClient(factory), executeCommand);
+app.get("/bot_definition", schema);
+app.get("/", schema);
+
+export default app;

--- a/ts/examples/faq/src/factory.ts
+++ b/ts/examples/faq/src/factory.ts
@@ -1,0 +1,8 @@
+import { BotClientFactory } from "@open-ic/openchat-botclient-ts";
+
+export const factory = new BotClientFactory({
+  openchatPublicKey: process.env.OC_PUBLIC!,
+  icHost: process.env.IC_HOST!,
+  identityPrivateKey: process.env.IDENTITY_PRIVATE!,
+  openStorageCanisterId: process.env.STORAGE_INDEX_CANISTER!,
+});

--- a/ts/examples/faq/src/handlers/ask.ts
+++ b/ts/examples/faq/src/handlers/ask.ts
@@ -1,4 +1,5 @@
 import { Response } from "express";
+import fs from "fs";
 import path from "path";
 import { argumentsInvalid } from "@open-ic/openchat-botclient-ts";
 import { WithBotClient } from "../types";
@@ -10,12 +11,17 @@ import { openIndex, search, Chunk } from "../rag/store";
 const indexPath = path.resolve(process.cwd(), process.env.FAQ_INDEX || "./data/faq.db");
 const topK = Number(process.env.TOP_K || 4);
 
-let dbPromise: ReturnType<typeof openIndex> | null = null;
+let cachedDb: ReturnType<typeof openIndex> | null = null;
 function getDb() {
-  if (!dbPromise) {
-    dbPromise = openIndex(indexPath);
+  if (!cachedDb) {
+    if (!fs.existsSync(indexPath)) {
+      throw new Error(
+        `FAQ index not found at ${indexPath}. Run \`npm run ingest\` to build it.`
+      );
+    }
+    cachedDb = openIndex(indexPath);
   }
-  return dbPromise;
+  return cachedDb;
 }
 
 function buildPrompt(question: string, chunks: Chunk[]): ChatMessage[] {
@@ -36,16 +42,17 @@ function buildPrompt(question: string, chunks: Chunk[]): ChatMessage[] {
 
 export default async function ask(req: WithBotClient, res: Response) {
   const client = req.botClient;
-  const placeholder = (
-    await client.createTextMessage("Searching the FAQ...")
-  ).setFinalised(false);
-  res.status(200).json(success(placeholder));
 
   const question = client.stringArg("question");
   if (question === undefined) {
     res.status(400).send(argumentsInvalid());
     return;
   }
+
+  const placeholder = (
+    await client.createTextMessage("Searching the FAQ...")
+  ).setFinalised(false);
+  res.status(200).json(success(placeholder));
 
   try {
     const db = getDb();

--- a/ts/examples/faq/src/handlers/ask.ts
+++ b/ts/examples/faq/src/handlers/ask.ts
@@ -9,7 +9,15 @@ import { chat, ChatMessage } from "../rag/llm";
 import { openIndex, search, Chunk } from "../rag/store";
 
 const indexPath = path.resolve(process.cwd(), process.env.FAQ_INDEX || "./data/faq.db");
-const topK = Number(process.env.TOP_K || 4);
+
+function resolveTopK(raw: string | undefined): number {
+  const fallback = 4;
+  if (raw === undefined) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return parsed;
+}
+const topK = resolveTopK(process.env.TOP_K);
 
 let cachedDb: ReturnType<typeof openIndex> | null = null;
 function getDb() {
@@ -49,29 +57,42 @@ export default async function ask(req: WithBotClient, res: Response) {
     return;
   }
 
-  const placeholder = (
-    await client.createTextMessage("Searching the FAQ...")
-  ).setFinalised(false);
-  res.status(200).json(success(placeholder));
-
   try {
+    const placeholder = (
+      await client.createTextMessage("Searching the FAQ...")
+    ).setFinalised(false);
+    res.status(200).json(success(placeholder));
+
     const db = getDb();
     const queryEmbedding = await embed(question);
     const chunks = search(db, queryEmbedding, topK);
-    const messages = buildPrompt(question, chunks);
-    const answer = await chat(messages);
-    const finalText = answer && answer.trim().length > 0
-      ? answer
-      : "I could not find an answer in the FAQ.";
+
+    let finalText: string;
+    if (chunks.length === 0) {
+      finalText = "I could not find anything relevant in the FAQ to answer that.";
+    } else {
+      const messages = buildPrompt(question, chunks);
+      const answer = await chat(messages);
+      finalText = answer.trim();
+    }
+
     const msg = (await client.createTextMessage(finalText))
       .setFinalised(true)
       .setBlockLevelMarkdown(true);
     await client.sendMessage(msg);
   } catch (err) {
     console.error("ask handler failed:", err);
-    const msg = (await client.createTextMessage(
-      "Sorry, I ran into an error while answering. Please try again later."
-    )).setFinalised(true);
-    await client.sendMessage(msg);
+    if (!res.headersSent) {
+      res.status(500).send("Internal server error");
+      return;
+    }
+    try {
+      const msg = (await client.createTextMessage(
+        "Sorry, I ran into an error while answering. Please try again later."
+      )).setFinalised(true);
+      await client.sendMessage(msg);
+    } catch (sendErr) {
+      console.error("ask handler failed to report error:", sendErr);
+    }
   }
 }

--- a/ts/examples/faq/src/handlers/ask.ts
+++ b/ts/examples/faq/src/handlers/ask.ts
@@ -1,0 +1,70 @@
+import { Response } from "express";
+import path from "path";
+import { argumentsInvalid } from "@open-ic/openchat-botclient-ts";
+import { WithBotClient } from "../types";
+import { success } from "./success";
+import { embed } from "../rag/embed";
+import { chat, ChatMessage } from "../rag/llm";
+import { openIndex, search, Chunk } from "../rag/store";
+
+const indexPath = path.resolve(process.cwd(), process.env.FAQ_INDEX || "./data/faq.db");
+const topK = Number(process.env.TOP_K || 4);
+
+let dbPromise: ReturnType<typeof openIndex> | null = null;
+function getDb() {
+  if (!dbPromise) {
+    dbPromise = openIndex(indexPath);
+  }
+  return dbPromise;
+}
+
+function buildPrompt(question: string, chunks: Chunk[]): ChatMessage[] {
+  const context = chunks.map((c, i) => `[${i + 1}] ${c.text}`).join("\n\n");
+  return [
+    {
+      role: "system",
+      content:
+        "You are a helpful FAQ assistant. Answer the user's question using only the provided context. " +
+        "If the context does not contain the answer, say so honestly. Keep answers concise.",
+    },
+    {
+      role: "user",
+      content: `Context:\n${context}\n\nQuestion: ${question}`,
+    },
+  ];
+}
+
+export default async function ask(req: WithBotClient, res: Response) {
+  const client = req.botClient;
+  const placeholder = (
+    await client.createTextMessage("Searching the FAQ...")
+  ).setFinalised(false);
+  res.status(200).json(success(placeholder));
+
+  const question = client.stringArg("question");
+  if (question === undefined) {
+    res.status(400).send(argumentsInvalid());
+    return;
+  }
+
+  try {
+    const db = getDb();
+    const queryEmbedding = await embed(question);
+    const chunks = search(db, queryEmbedding, topK);
+    const messages = buildPrompt(question, chunks);
+    const answer = await chat(messages);
+    const finalText = answer && answer.trim().length > 0
+      ? answer
+      : "I could not find an answer in the FAQ.";
+    const msg = (await client.createTextMessage(finalText))
+      .setFinalised(true)
+      .setBlockLevelMarkdown(true);
+    await client.sendMessage(msg);
+  } catch (err) {
+    console.error("ask handler failed:", err);
+    const msg = (await client.createTextMessage(
+      "Sorry, I ran into an error while answering. Please try again later."
+    )).setFinalised(true);
+    await client.sendMessage(msg);
+  }
+}

--- a/ts/examples/faq/src/handlers/executeCommand.ts
+++ b/ts/examples/faq/src/handlers/executeCommand.ts
@@ -1,0 +1,23 @@
+import { commandNotFound } from "@open-ic/openchat-botclient-ts";
+import { Request, Response } from "express";
+import { WithBotClient } from "../types";
+import ask from "./ask";
+
+function hasBotClient(req: Request): req is WithBotClient {
+  return (req as WithBotClient).botClient !== undefined;
+}
+
+export default function executeCommand(req: Request, res: Response) {
+  if (!hasBotClient(req)) {
+    res.status(500).send("Bot client not initialised");
+    return;
+  }
+  const client = req.botClient;
+
+  switch (client.commandName) {
+    case "ask":
+      return ask(req as WithBotClient, res);
+    default:
+      res.status(400).send(commandNotFound());
+  }
+}

--- a/ts/examples/faq/src/handlers/schema.ts
+++ b/ts/examples/faq/src/handlers/schema.ts
@@ -1,0 +1,47 @@
+import { BotDefinition, Permissions } from "@open-ic/openchat-botclient-ts";
+import { Request, Response } from "express";
+
+const emptyPermissions = {
+  chat: [],
+  community: [],
+  message: [],
+};
+
+function getBotDefinition(): BotDefinition {
+  return {
+    description:
+      "Retrieval-augmented FAQ bot. Answers user questions by searching a local FAQ corpus and consulting an LLM.",
+    commands: [
+      {
+        name: "ask",
+        default_role: "Participant",
+        description: "Ask a question about the FAQ corpus",
+        permissions: Permissions.encodePermissions({
+          ...emptyPermissions,
+          message: ["Text"],
+        }),
+        direct_messages: true,
+        params: [
+          {
+            name: "question",
+            required: true,
+            description: "The question to ask",
+            placeholder: "What do you want to know?",
+            param_type: {
+              StringParam: {
+                min_length: 1,
+                max_length: 1000,
+                choices: [],
+                multi_line: true,
+              },
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export default function schema(_: Request, res: Response) {
+  res.status(200).json(getBotDefinition());
+}

--- a/ts/examples/faq/src/handlers/success.ts
+++ b/ts/examples/faq/src/handlers/success.ts
@@ -1,0 +1,7 @@
+import { Message } from "@open-ic/openchat-botclient-ts";
+
+export function success(msg?: Message) {
+  return {
+    message: msg?.toResponse(),
+  };
+}

--- a/ts/examples/faq/src/middleware/botclient.ts
+++ b/ts/examples/faq/src/middleware/botclient.ts
@@ -1,0 +1,28 @@
+import {
+  accessTokenNotFound,
+  BadRequestError,
+  BotClientFactory,
+} from "@open-ic/openchat-botclient-ts";
+import { NextFunction, Request, Response } from "express";
+import { WithBotClient } from "../types";
+
+export function createCommandChatClient(factory: BotClientFactory) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    try {
+      const token = req.headers["x-oc-jwt"];
+      if (!token) {
+        throw new BadRequestError(accessTokenNotFound());
+      }
+      (req as WithBotClient).botClient = factory.createClientFromCommandJwt(
+        token as string
+      );
+      next();
+    } catch (err: any) {
+      if (err instanceof BadRequestError) {
+        res.status(400).send(err.message);
+      } else {
+        res.status(500).send(err.message);
+      }
+    }
+  };
+}

--- a/ts/examples/faq/src/rag/embed.ts
+++ b/ts/examples/faq/src/rag/embed.ts
@@ -3,6 +3,8 @@
  * Swap via EMBEDDING_PROVIDER env var.
  */
 
+const EMBED_TIMEOUT_MS = 60_000;
+
 export async function embed(text: string): Promise<number[]> {
   const provider = process.env.EMBEDDING_PROVIDER || "hf";
   switch (provider) {
@@ -21,6 +23,7 @@ async function embedHuggingFace(text: string): Promise<number[]> {
   }
   const url = `https://api-inference.huggingface.co/pipeline/feature-extraction/${model}`;
   const res = await fetch(url, {
+    signal: AbortSignal.timeout(EMBED_TIMEOUT_MS),
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,

--- a/ts/examples/faq/src/rag/embed.ts
+++ b/ts/examples/faq/src/rag/embed.ts
@@ -1,0 +1,40 @@
+/**
+ * Embedding provider. Default: Hugging Face Inference API (free tier).
+ * Swap via EMBEDDING_PROVIDER env var.
+ */
+
+export async function embed(text: string): Promise<number[]> {
+  const provider = process.env.EMBEDDING_PROVIDER || "hf";
+  switch (provider) {
+    case "hf":
+      return embedHuggingFace(text);
+    default:
+      throw new Error(`Unknown EMBEDDING_PROVIDER: ${provider}`);
+  }
+}
+
+async function embedHuggingFace(text: string): Promise<number[]> {
+  const model = process.env.HF_EMBEDDING_MODEL || "sentence-transformers/all-MiniLM-L6-v2";
+  const token = process.env.HF_TOKEN;
+  if (!token) {
+    throw new Error("HF_TOKEN is required for the Hugging Face embedding provider");
+  }
+  const url = `https://api-inference.huggingface.co/pipeline/feature-extraction/${model}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ inputs: text, options: { wait_for_model: true } }),
+  });
+  if (!res.ok) {
+    throw new Error(`HF embedding failed: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as number[] | number[][];
+  // Some HF sentence-transformer endpoints return [dim] directly; others return [[dim]].
+  if (Array.isArray(data) && Array.isArray(data[0])) {
+    return data[0] as number[];
+  }
+  return data as number[];
+}

--- a/ts/examples/faq/src/rag/embed.ts
+++ b/ts/examples/faq/src/rag/embed.ts
@@ -31,10 +31,26 @@ async function embedHuggingFace(text: string): Promise<number[]> {
   if (!res.ok) {
     throw new Error(`HF embedding failed: ${res.status} ${await res.text()}`);
   }
-  const data = (await res.json()) as number[] | number[][];
-  // Some HF sentence-transformer endpoints return [dim] directly; others return [[dim]].
-  if (Array.isArray(data) && Array.isArray(data[0])) {
+  const data = (await res.json()) as unknown;
+  return toSentenceEmbedding(data);
+}
+
+// Sentence-transformer endpoints may return [dim] (pooled) or [[dim]]
+// (batch of one). Token-level outputs like [tokens][dim] are rejected
+// so the caller sees a clear error instead of a silently-wrong vector.
+function toSentenceEmbedding(data: unknown): number[] {
+  if (!Array.isArray(data) || data.length === 0) {
+    throw new Error("HF embedding: unexpected empty response");
+  }
+  if (typeof data[0] === "number") {
+    return data as number[];
+  }
+  if (Array.isArray(data[0]) && data.length === 1 && typeof data[0][0] === "number") {
     return data[0] as number[];
   }
-  return data as number[];
+  throw new Error(
+    "HF embedding: response is not a sentence embedding. " +
+      "The configured model likely returns token-level vectors; " +
+      "use a sentence-transformers model or switch EMBEDDING_PROVIDER."
+  );
 }

--- a/ts/examples/faq/src/rag/llm.ts
+++ b/ts/examples/faq/src/rag/llm.ts
@@ -2,6 +2,8 @@
  * LLM provider. Swap via LLM_PROVIDER env var.
  */
 
+const CHAT_TIMEOUT_MS = 120_000;
+
 export interface ChatMessage {
   role: "system" | "user" | "assistant";
   content: string;
@@ -19,6 +21,16 @@ export async function chat(messages: ChatMessage[]): Promise<string> {
   }
 }
 
+function extractAnswer(data: any, provider: string): string {
+  const content = data?.choices?.[0]?.message?.content;
+  if (typeof content !== "string" || content.length === 0) {
+    throw new Error(
+      `${provider} chat response missing choices[0].message.content: ${JSON.stringify(data).slice(0, 400)}`
+    );
+  }
+  return content;
+}
+
 async function chatHuggingFace(messages: ChatMessage[]): Promise<string> {
   const model = process.env.HF_LLM_MODEL || "HuggingFaceH4/zephyr-7b-beta";
   const token = process.env.HF_TOKEN;
@@ -27,6 +39,7 @@ async function chatHuggingFace(messages: ChatMessage[]): Promise<string> {
   }
   const url = `https://api-inference.huggingface.co/models/${model}/v1/chat/completions`;
   const res = await fetch(url, {
+    signal: AbortSignal.timeout(CHAT_TIMEOUT_MS),
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -42,8 +55,7 @@ async function chatHuggingFace(messages: ChatMessage[]): Promise<string> {
   if (!res.ok) {
     throw new Error(`HF chat failed: ${res.status} ${await res.text()}`);
   }
-  const data = (await res.json()) as any;
-  return data.choices?.[0]?.message?.content ?? "";
+  return extractAnswer(await res.json(), "HF");
 }
 
 async function chatGroq(messages: ChatMessage[]): Promise<string> {
@@ -53,6 +65,7 @@ async function chatGroq(messages: ChatMessage[]): Promise<string> {
   }
   const model = process.env.GROQ_MODEL || "llama-3.1-8b-instant";
   const res = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    signal: AbortSignal.timeout(CHAT_TIMEOUT_MS),
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -68,6 +81,5 @@ async function chatGroq(messages: ChatMessage[]): Promise<string> {
   if (!res.ok) {
     throw new Error(`Groq chat failed: ${res.status} ${await res.text()}`);
   }
-  const data = (await res.json()) as any;
-  return data.choices?.[0]?.message?.content ?? "";
+  return extractAnswer(await res.json(), "Groq");
 }

--- a/ts/examples/faq/src/rag/llm.ts
+++ b/ts/examples/faq/src/rag/llm.ts
@@ -1,0 +1,73 @@
+/**
+ * LLM provider. Swap via LLM_PROVIDER env var.
+ */
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export async function chat(messages: ChatMessage[]): Promise<string> {
+  const provider = process.env.LLM_PROVIDER || "hf";
+  switch (provider) {
+    case "hf":
+      return chatHuggingFace(messages);
+    case "groq":
+      return chatGroq(messages);
+    default:
+      throw new Error(`Unknown LLM_PROVIDER: ${provider}`);
+  }
+}
+
+async function chatHuggingFace(messages: ChatMessage[]): Promise<string> {
+  const model = process.env.HF_LLM_MODEL || "HuggingFaceH4/zephyr-7b-beta";
+  const token = process.env.HF_TOKEN;
+  if (!token) {
+    throw new Error("HF_TOKEN is required for the Hugging Face LLM provider");
+  }
+  const url = `https://api-inference.huggingface.co/models/${model}/v1/chat/completions`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: 512,
+      temperature: 0.2,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`HF chat failed: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as any;
+  return data.choices?.[0]?.message?.content ?? "";
+}
+
+async function chatGroq(messages: ChatMessage[]): Promise<string> {
+  const apiKey = process.env.GROQ_API_KEY;
+  if (!apiKey) {
+    throw new Error("GROQ_API_KEY is required for the Groq LLM provider");
+  }
+  const model = process.env.GROQ_MODEL || "llama-3.1-8b-instant";
+  const res = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      max_tokens: 512,
+      temperature: 0.2,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Groq chat failed: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as any;
+  return data.choices?.[0]?.message?.content ?? "";
+}

--- a/ts/examples/faq/src/rag/store.ts
+++ b/ts/examples/faq/src/rag/store.ts
@@ -31,10 +31,14 @@ export function initIndex(path: string, dim: number): Database.Database {
 }
 
 export function insertChunk(db: Database.Database, text: string, embedding: number[]): void {
-  const info = db.prepare("INSERT INTO chunks (text) VALUES (?)").run(text);
-  const id = info.lastInsertRowid as number;
-  db.prepare("INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)")
-    .run(id, Buffer.from(new Float32Array(embedding).buffer));
+  const insertText = db.prepare("INSERT INTO chunks (text) VALUES (?)");
+  const insertVec = db.prepare("INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)");
+  const tx = db.transaction((t: string, e: number[]) => {
+    const info = insertText.run(t);
+    const id = info.lastInsertRowid as number;
+    insertVec.run(id, Buffer.from(new Float32Array(e).buffer));
+  });
+  tx(text, embedding);
 }
 
 export function search(db: Database.Database, queryEmbedding: number[], k: number): Chunk[] {

--- a/ts/examples/faq/src/rag/store.ts
+++ b/ts/examples/faq/src/rag/store.ts
@@ -1,0 +1,60 @@
+/**
+ * sqlite-vec backed FAQ index. Build with scripts/ingest.ts, query at runtime.
+ */
+import Database from "better-sqlite3";
+import * as sqliteVec from "sqlite-vec";
+
+export interface Chunk {
+  id: number;
+  text: string;
+  score: number;
+}
+
+function openDb(path: string): Database.Database {
+  const db = new Database(path);
+  sqliteVec.load(db);
+  return db;
+}
+
+export function initIndex(path: string, dim: number): Database.Database {
+  const db = openDb(path);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS chunks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      text TEXT NOT NULL
+    );
+    CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(
+      embedding float[${dim}]
+    );
+  `);
+  return db;
+}
+
+export function insertChunk(db: Database.Database, text: string, embedding: number[]): void {
+  const info = db.prepare("INSERT INTO chunks (text) VALUES (?)").run(text);
+  const id = info.lastInsertRowid as number;
+  db.prepare("INSERT INTO vec_chunks (rowid, embedding) VALUES (?, ?)")
+    .run(id, Buffer.from(new Float32Array(embedding).buffer));
+}
+
+export function search(db: Database.Database, queryEmbedding: number[], k: number): Chunk[] {
+  const rows = db
+    .prepare(
+      `SELECT chunks.id as id, chunks.text as text, vec_chunks.distance as distance
+       FROM vec_chunks
+       JOIN chunks ON chunks.id = vec_chunks.rowid
+       WHERE vec_chunks.embedding MATCH ?
+       ORDER BY vec_chunks.distance
+       LIMIT ?`
+    )
+    .all(Buffer.from(new Float32Array(queryEmbedding).buffer), k) as Array<{
+    id: number;
+    text: string;
+    distance: number;
+  }>;
+  return rows.map((r) => ({ id: r.id, text: r.text, score: 1 - r.distance }));
+}
+
+export function openIndex(path: string): Database.Database {
+  return openDb(path);
+}

--- a/ts/examples/faq/src/rag/store.ts
+++ b/ts/examples/faq/src/rag/store.ts
@@ -43,9 +43,8 @@ export function search(db: Database.Database, queryEmbedding: number[], k: numbe
       `SELECT chunks.id as id, chunks.text as text, vec_chunks.distance as distance
        FROM vec_chunks
        JOIN chunks ON chunks.id = vec_chunks.rowid
-       WHERE vec_chunks.embedding MATCH ?
-       ORDER BY vec_chunks.distance
-       LIMIT ?`
+       WHERE vec_chunks.embedding MATCH ? AND k = ?
+       ORDER BY vec_chunks.distance`
     )
     .all(Buffer.from(new Float32Array(queryEmbedding).buffer), k) as Array<{
     id: number;

--- a/ts/examples/faq/src/server.ts
+++ b/ts/examples/faq/src/server.ts
@@ -1,0 +1,8 @@
+import "dotenv/config";
+import app from "./app";
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`FAQ bot is running on port ${PORT}`);
+});

--- a/ts/examples/faq/src/types.ts
+++ b/ts/examples/faq/src/types.ts
@@ -1,0 +1,6 @@
+import { BotClient } from "@open-ic/openchat-botclient-ts";
+import { Request } from "express";
+
+export interface WithBotClient extends Request {
+  botClient: BotClient;
+}

--- a/ts/examples/faq/tsconfig.json
+++ b/ts/examples/faq/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "scripts/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/ts/examples/faq/tsconfig.json
+++ b/ts/examples/faq/tsconfig.json
@@ -7,8 +7,14 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "src"
   },
-  "include": ["src/**/*", "scripts/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }


### PR DESCRIPTION
Closes #158.

## Summary
Adds `ts/examples/faq/`, a TypeScript Command-bot example implementing `/ask <question>`:

- Embed the user's question → top-k search a local `sqlite-vec` index → compose a grounded answer via a configurable LLM provider.
- Ingest script (`scripts/ingest.ts`) builds the vector index from any Markdown source, so the FAQ corpus is trivial to replace.
- Skeleton mirrors `ts/examples/openai` (same Express + JWT middleware pattern, same `BotDefinition` shape).

## Provider choices
- Default embedding: Hugging Face Inference API (`sentence-transformers/all-MiniLM-L6-v2`) — free tier.
- Default chat: Hugging Face Inference API; Groq supported as an alternative via `LLM_PROVIDER=groq`.
- Both providers are env-swappable from `src/rag/{embed,llm}.ts`, and new providers only require a `switch` branch.

## Open questions
Noted in `ts/examples/faq/README.md`, repeated here for visibility:

- **FAQ data source.** `data/faq.md` is placeholder content. Happy to swap for an authoritative source (docs excerpt, curated Q&A, etc.) on request.
- **Deployment shape.** Published as off-chain Node to match the other `ts/examples`. An on-chain canister variant would be a separate, larger change — let me know if that's preferred instead.
- **Preferred provider default.** HF free tier was chosen to keep the example usable without a paid account. Open to changing the default if there's a preferred provider.

## Test plan
- [x] `npm install` in `ts/library` then `ts/examples/faq` succeeds
- [x] `tsc --strict` builds cleanly (no errors, no warnings)
- [x] Upstream CI (run fmt / run clippy / run unit tests / CodeQL Analyze for actions / javascript-typescript / rust) passes on the fork
- [ ] End-to-end: `npm run ingest` with a real `HF_TOKEN` produces `data/faq.db`; `npm run dev` + `/register_bot` on a local OpenChat answers an `/ask` call — I can run this against a local `open-chat` checkout on request

## Notes on the review pass
This branch already went through a self-review cycle (fork-internal CI + CodeRabbit). 12 items were raised; 10 were applied, 2 were intentionally skipped to stay consistent with `ts/examples/openai` (`x-oc-jwt` header normalisation and the 500-response sanitisation) — happy to align those if the project has a preference either way.